### PR TITLE
delete leases with no namespace

### DIFF
--- a/pkg/controller/leases.go
+++ b/pkg/controller/leases.go
@@ -151,10 +151,7 @@ func reconcilePoolStates() []*v1.Pool {
 			serverNetworks := networksInUse[pool.Spec.Server]
 			if _, ok := serverNetworks[networkName]; !ok {
 				availableNetworks++
-			} else {
-				log.Printf("network %s already in use", networkName)
 			}
-
 		}
 		pool.Status.NetworkAvailable = availableNetworks
 	}


### PR DESCRIPTION
Changes:

- delete leases which no longer have an associated namespace as defined by the label `vsphere-capacity-manager.splat-team.io/lease-namespace`. 