### PR TITLE
add support for network types

### DIFF
--- a/config/crd/bases/vspherecapacitymanager.splat.io_leases.yaml
+++ b/config/crd/bases/vspherecapacitymanager.splat.io_leases.yaml
@@ -54,6 +54,19 @@ spec:
                 description: Memory is the amount of memory in GB allocated for this
                   lease
                 type: integer
+              network-type:
+                default: single-tenant
+                description: NetworkType defines the type of network required by the
+                  lease. by default, all networks are treated as single-tenant. single-tenant
+                  networks are only used by one CI jobs.  multi-tenant networks reside
+                  on a VLAN which may be used by multiple jobs.  disconnected networks
+                  aren't yet supported.
+                enum:
+                - ""
+                - disconnected
+                - single-tenant
+                - multi-tenant
+                type: string
               networks:
                 description: Networks is the number of networks requested
                 type: integer

--- a/pkg/apis/vspherecapacitymanager.splat.io/v1/leases_types.go
+++ b/pkg/apis/vspherecapacitymanager.splat.io/v1/leases_types.go
@@ -5,11 +5,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type NetworkType string
+
 const (
-	LeaseKind      = "Lease"
-	APIGroupName   = "vsphere-capacity-manager.splat-team.io"
-	LeaseFinalizer = "vsphere-capacity-manager.splat-team.io/lease-finalizer"
-	LeaseNamespace = "vsphere-capacity-manager.splat-team.io/lease-namespace"
+	LeaseKind               = "Lease"
+	APIGroupName            = "vsphere-capacity-manager.splat-team.io"
+	LeaseFinalizer          = "vsphere-capacity-manager.splat-team.io/lease-finalizer"
+	LeaseNamespace          = "vsphere-capacity-manager.splat-team.io/lease-namespace"
+	NetworkTypeDisconnected = NetworkType("disconnected")
+	NetworkTypeSingleTenant = NetworkType("single-tenant")
+	NetworkTypeMultiTenant  = NetworkType("multi-tenant")
 )
 
 // +genclient
@@ -47,6 +52,17 @@ type LeaseSpec struct {
 	// pool
 	// +optional
 	RequiredPool string `json:"required-pool,omitempty"`
+
+	// NetworkType defines the type of network required by the lease.
+	// by default, all networks are treated as single-tenant. single-tenant networks
+	// are only used by one CI jobs.  multi-tenant networks reside on a
+	// VLAN which may be used by multiple jobs.  disconnected networks aren't yet
+	// supported.
+	// +kubebuilder:validation:Enum="";disconnected;single-tenant;multi-tenant
+	// +kubebuilder:default=single-tenant
+	// +optional
+	NetworkType NetworkType `json:"network-type"`
+
 	// BoskosLeaseID is the ID of the lease in Boskos associated with this lease
 	// +optional
 	BoskosLeaseID string `json:"boskos-lease-id,omitempty"`

--- a/pkg/apis/vspherecapacitymanager.splat.io/v1/network_types.go
+++ b/pkg/apis/vspherecapacitymanager.splat.io/v1/network_types.go
@@ -8,6 +8,7 @@ const (
 	NETWORKS_LAST_LEASE_UPDATE_ANNOTATION = "vspherecapacitymanager.splat.io/last-network-update"
 	NetworkFinalizer                      = "vsphere-capacity-manager.splat-team.io/network-finalizer"
 	NetworkKind                           = "Network"
+	NetworkTypeLabel                      = "vsphere-capacity-manager.splat-team.io/network-type"
 )
 
 // +genclient

--- a/pkg/controller/pools.go
+++ b/pkg/controller/pools.go
@@ -112,7 +112,7 @@ func (l *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			reconciledPool.Status.DeepCopyInto(&pool.Status)
 			err := l.Client.Status().Update(ctx, pool)
 			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("error udpating pool status: %w", err)
+				return ctrl.Result{}, fmt.Errorf("error updating pool status: %w", err)
 			}
 		}
 	}

--- a/pkg/controller/pools.go
+++ b/pkg/controller/pools.go
@@ -112,7 +112,7 @@ func (l *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			reconciledPool.Status.DeepCopyInto(&pool.Status)
 			err := l.Client.Status().Update(ctx, pool)
 			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("error initializing pool status: %w", err)
+				return ctrl.Result{}, fmt.Errorf("error udpating pool status: %w", err)
 			}
 		}
 	}

--- a/pkg/utils/pools.go
+++ b/pkg/utils/pools.go
@@ -72,7 +72,9 @@ func GetPoolWithStrategy(lease *v1.Lease, pools []*v1.Pool, strategy v1.Allocati
 		pool.Spec.VSpherePlatformFailureDomainSpec.DeepCopyInto(
 			&lease.Status.VSpherePlatformFailureDomainSpec)
 
-		lease.Finalizers = append(lease.Finalizers, v1.LeaseFinalizer)
+		// drop the networks from the topology. networks will be assigned in a later step.
+		lease.Status.Topology.Networks = []string{}
+
 		return pool, nil
 	}
 }


### PR DESCRIPTION
changes:
- added support for network types: single-tenant, multi-tenant, disconnected

by default, all leases will utilize a single-tenant VLAN which means that the VLAN will only be used for a given job.  multi-tenant allows a job to share a VLAN with other jobs.  disconnected is not yet supported.  additional network types are to be added as needed.