### PR TITLE
SPLAT-1705: fixed network logic to find matching network for multi vCenter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Binaries for programs and plugins
+bin

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -1,2 +1,12 @@
+#!/bin/bash
+
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
+
 echo KUBEBUILDER_ASSETS=$KUBEBUILDER_ASSETS
-ginkgo -r
+
+GINKGO=${GINKGO:-"go run ${REPO_ROOT}/vendor/github.com/onsi/ginkgo/v2/ginkgo"}
+
+${GINKGO} -r

--- a/pkg/controller/leases.go
+++ b/pkg/controller/leases.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	boskosIdLabel = "boskos-lease-id"
+	BoskosIdLabel = "boskos-lease-id"
 )
 
 type LeaseReconciler struct {
@@ -213,7 +213,7 @@ func (l *LeaseReconciler) getCommonNetworkForLease(lease *v1.Lease) (*v1.Network
 	if lease.Spec.VCpus == 0 && lease.Spec.Memory == 0 {
 		return nil, fmt.Errorf("network-only lease %s", lease.Name)
 	}
-	if leaseID, exists = lease.Labels[boskosIdLabel]; !exists {
+	if leaseID, exists = lease.Labels[BoskosIdLabel]; !exists {
 		return nil, fmt.Errorf("no lease label found for %s", lease.Name)
 	}
 
@@ -222,11 +222,9 @@ func (l *LeaseReconciler) getCommonNetworkForLease(lease *v1.Lease) (*v1.Network
 			// this is a network-only lease. do not consider it.
 			continue
 		}
-		if thisLeaseID, exists := _lease.Labels[boskosIdLabel]; !exists {
+		if thisLeaseID, exists := _lease.Labels[BoskosIdLabel]; !exists {
 			continue
 		} else if thisLeaseID != leaseID {
-			continue
-		} else if lease.Status.Server != _lease.Status.Server {
 			continue
 		}
 		for _, ownerRef := range _lease.OwnerReferences {

--- a/test/manifests/pool-test-2.com-IBMCloud-vcs-ci-workload.yaml
+++ b/test/manifests/pool-test-2.com-IBMCloud-vcs-ci-workload.yaml
@@ -1,0 +1,59 @@
+apiVersion: vsphere-capacity-manager.splat-team.io/v1
+kind: Pool
+metadata:
+  creationTimestamp: null
+  name: test-2.com-IBMCloud-vcs-ci-workload
+spec:
+  exclude: false
+  ibmPoolSpec:
+    datacenter: dal10
+    pod: dal10.pod03
+  memory: 2684
+  name: test-2.com-IBMCloud-vcs-ci-workload
+  region: us-central
+  server: test-2.com
+  storage: 0
+  topology:
+    computeCluster: /cidatacenter-2/host/vcs-ci-workload
+    datacenter: /cidatacenter-2
+    datastore: /cidatacenter-2/datastore/vsanDatastore
+    networks:
+    - /cidatacenter-2/network/ci-vlan-1302
+    - /cidatacenter-2/network/ci-vlan-1300
+    - /cidatacenter-2/network/ci-vlan-1298
+    - /cidatacenter-2/network/ci-vlan-1296
+    - /cidatacenter-2/network/ci-vlan-1289
+    - /cidatacenter-2/network/ci-vlan-1287
+    - /cidatacenter-2/network/ci-vlan-1284
+    - /cidatacenter-2/network/ci-vlan-1279
+    - /cidatacenter-2/network/ci-vlan-1274
+    - /cidatacenter-2/network/ci-vlan-1272
+    - /cidatacenter-2/network/ci-vlan-1271
+    - /cidatacenter-2/network/ci-vlan-1260
+    - /cidatacenter-2/network/ci-vlan-1255
+    - /cidatacenter-2/network/ci-vlan-1254
+    - /cidatacenter-2/network/ci-vlan-1249
+    - /cidatacenter-2/network/ci-vlan-1246
+    - /cidatacenter-2/network/ci-vlan-1243
+    - /cidatacenter-2/network/ci-vlan-1240
+    - /cidatacenter-2/network/ci-vlan-1238
+    - /cidatacenter-2/network/ci-vlan-1237
+    - /cidatacenter-2/network/ci-vlan-1235
+    - /cidatacenter-2/network/ci-vlan-1234
+    - /cidatacenter-2/network/ci-vlan-1233
+    - /cidatacenter-2/network/ci-vlan-1232
+    - /cidatacenter-2/network/ci-vlan-1229
+    - /cidatacenter-2/network/ci-vlan-1227
+    - /cidatacenter-2/network/ci-vlan-1225
+    - /cidatacenter-2/network/ci-vlan-1207
+    - /cidatacenter-2/network/ci-vlan-1197
+    - /cidatacenter-2/network/ci-vlan-1148
+    - /cidatacenter-2/network/ci-vlan-956
+  vcpus: 240
+  zone: us-central-1a
+status:
+  datastore-available: 0
+  initialized: false
+  memory-available: 0
+  network-available: 0
+  vcpus-available: 0

--- a/test/util.go
+++ b/test/util.go
@@ -3,6 +3,7 @@ package test
 import (
 	"fmt"
 	v1 "github.com/openshift-splat-team/vsphere-capacity-manager/pkg/apis/vspherecapacitymanager.splat.io/v1"
+	"github.com/openshift-splat-team/vsphere-capacity-manager/pkg/controller"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -25,6 +26,7 @@ func GetLease() *lease {
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "sample-lease-",
 				Namespace:    "default",
+				Labels:       make(map[string]string),
 			},
 		},
 	}
@@ -40,6 +42,12 @@ func (r *lease) WithShape(shape shape) *lease {
 	r.lease.Spec.Memory = int(16 * int64(shape))
 	r.lease.Spec.Storage = int(120 * int64(shape))
 	r.lease.Spec.Networks = int(1 * int64(shape))
+
+	return r
+}
+
+func (r *lease) WithBoskosID(boskosID string) *lease {
+	r.lease.Labels[controller.BoskosIdLabel] = boskosID
 
 	return r
 }


### PR DESCRIPTION
SPLAT-1705

### Changes
- Fixed lease logic to match networks for multi vcenter
- Added tests for checking networks match when multiple vcenters are targeted
- Made BoskosIDLabel public
- Updated utils to allow setting boskos id label
- Fixed test.sh to use binary from vendor