### PR TITLE
feat: add comprehensive prometheus metrics for network types, pool ut…

### DIFF
--- a/doc/ipaddress-slot-waste.md
+++ b/doc/ipaddress-slot-waste.md
@@ -1,0 +1,54 @@
+# IP Address Slot Waste in Network Resources
+
+## Problem
+
+Every Network resource's `ipAddresses` list reserves the first two indices for the network address and gateway:
+
+| Index | Value | Purpose |
+|-------|-------|---------|
+| 0 | Network address (e.g., `.0` or `.128`) | Never assigned to a node |
+| 1 | Gateway (e.g., `.1` or `.129`) | Never assigned to a node |
+| 2 | First usable IP | LB / API VIP (UPI) or API VIP (IPI) |
+| 3 | Second usable IP | Bootstrap (UPI) or Ingress VIP (IPI) |
+| 4+ | Remaining IPs | Control plane nodes, then workers |
+
+Both IPI and UPI scripts in `openshift/release` skip indices 0 and 1:
+
+**IPI** (`ipi-conf-vsphere-vips-vcm-commands.sh`):
+```bash
+jq -r --argjson N 2 '.spec.ipAddresses[$N]'   # API VIP
+jq -r --argjson N 3 '.spec.ipAddresses[$N]'   # Ingress VIP
+```
+
+**UPI** (`upi-conf-vsphere-vcm-commands.sh`):
+```bash
+lb_ip_address=$(jq -r '.spec.ipAddresses[2]' "${NETWORK_CONFIG}")
+bootstrap_ip_address=$(jq -r '.spec.ipAddresses[3]' "${NETWORK_CONFIG}")
+# control plane starts at index 4, workers after that
+```
+
+The network address and gateway are redundant here — they're already available via the `gateway` and `machineNetworkCidr` fields on the Network spec.
+
+## Impact
+
+For single-tenant networks with 20 IPs, losing 2 slots is a ~10% overhead — not significant.
+
+For multi-tenant networks with sliding windows of 4-5 IPs, losing 2 slots to sentinels means only 2-3 usable addresses — **40-50% waste**.
+
+## Options
+
+### Option 1: Remove sentinel entries from `ipAddresses`
+
+Stop including the network address and gateway in `ipAddresses`. Start the list at what is currently index 2 (the first assignable IP). Update the IPI and UPI scripts to consume starting at index 0 instead of index 2.
+
+- Requires a coordinated change across `vsphere-capacity-manager` (network definitions) and `openshift/release` (step registry scripts).
+- Reclaims 2 IPs per network.
+- Cleaner long-term: `ipAddresses` contains only addresses that are actually assignable.
+
+### Option 2: Accept the overhead
+
+Keep the current convention. Size networks with 2 extra IPs to compensate.
+
+- Zero code changes.
+- Every new network continues to burn 2 IPs.
+- Multi-tenant sliding windows remain constrained.

--- a/doc/prometheus-queries.md
+++ b/doc/prometheus-queries.md
@@ -1,0 +1,236 @@
+# Prometheus Queries
+
+Useful PromQL queries for monitoring the vSphere Capacity Manager. All metrics are exposed on the `/metrics` endpoint.
+
+## Pool Capacity
+
+### CPU utilization per pool
+
+```promql
+pool_vcpus_utilization_ratio
+```
+
+Pools approaching 1.0 are running out of CPU capacity. Factor in `pool_no_schedule` to exclude disabled pools:
+
+```promql
+pool_vcpus_utilization_ratio and on(namespace, pool) pool_no_schedule == 0
+```
+
+### Memory utilization per pool
+
+```promql
+pool_memory_utilization_ratio
+```
+
+### Network utilization per pool
+
+```promql
+pool_networks_utilization_ratio
+```
+
+### Pools with high utilization (any resource above 80%)
+
+```promql
+pool_vcpus_utilization_ratio > 0.8
+  or pool_memory_utilization_ratio > 0.8
+  or pool_networks_utilization_ratio > 0.8
+```
+
+### Available resources per pool
+
+```promql
+pool_cpus_available
+pool_memory_available
+pool_networks_available
+```
+
+### Total vs available side by side
+
+```promql
+pool_cpus_total - pool_cpus_available
+```
+
+## Pool Scheduling State
+
+### Pools excluded from scheduling
+
+```promql
+pool_excluded == 1
+```
+
+### Pools with scheduling disabled
+
+```promql
+pool_no_schedule == 1
+```
+
+### Count of schedulable pools
+
+```promql
+count(pool_no_schedule == 0 and pool_excluded == 0)
+```
+
+## Networks by Type
+
+### Total networks per pool by type
+
+```promql
+pool_networks_total_by_type
+```
+
+### Available networks per pool by type
+
+```promql
+pool_networks_available_by_type
+```
+
+### Networks in use per type
+
+```promql
+pool_networks_total_by_type - pool_networks_available_by_type
+```
+
+### Multi-tenant network availability across all pools
+
+```promql
+sum(pool_networks_available_by_type{networkType="multi-tenant"})
+```
+
+### Network type breakdown for a specific pool
+
+```promql
+pool_networks_total_by_type{pool="devqe-pool-1"}
+```
+
+## Network Sharing
+
+### Lease count per network
+
+```promql
+network_lease_count
+```
+
+### Multi-tenant networks with the most leases
+
+```promql
+topk(10, network_lease_count{networkType="multi-tenant"})
+```
+
+### Networks with no active leases
+
+```promql
+network_lease_count == 0
+```
+
+## Leases
+
+### Active lease counts by phase
+
+```promql
+leases_counts
+```
+
+### Leases currently in Pending or Partial state
+
+```promql
+leases_counts{phase=~"Pending|Partial"}
+```
+
+### Total leases in use per pool
+
+```promql
+leases_in_use
+```
+
+## Lease Age
+
+### All lease ages
+
+```promql
+lease_age_seconds
+```
+
+### Leases older than 7 days
+
+```promql
+lease_age_seconds > 86400 * 7
+```
+
+### Leases older than 30 days
+
+```promql
+lease_age_seconds > 86400 * 30
+```
+
+### Top 10 oldest leases
+
+```promql
+topk(10, lease_age_seconds)
+```
+
+### Average lease age by network type
+
+```promql
+avg by (networkType) (lease_age_seconds)
+```
+
+## Lease Lifecycle
+
+### Lease transition rate (per 5 minutes)
+
+```promql
+rate(lease_transitions_total[5m])
+```
+
+### Lease delay rate (per 5 minutes)
+
+```promql
+rate(lease_delays_total[5m])
+```
+
+### Total leases fulfilled in the last hour
+
+```promql
+increase(lease_transitions_total{phase="Fulfilled"}[1h])
+```
+
+### Delay-to-fulfillment ratio (high values indicate scheduling pressure)
+
+```promql
+rate(lease_delays_total[1h]) / rate(lease_transitions_total{phase="Fulfilled"}[1h])
+```
+
+## Alerting Examples
+
+### Alert: pool CPU above 90%
+
+```promql
+pool_vcpus_utilization_ratio > 0.9
+  and on(namespace, pool) pool_no_schedule == 0
+  and on(namespace, pool) pool_excluded == 0
+```
+
+### Alert: no multi-tenant networks available
+
+```promql
+sum(pool_networks_available_by_type{networkType="multi-tenant"}) == 0
+```
+
+### Alert: lease stuck (not fulfilled after 30 minutes)
+
+```promql
+lease_age_seconds{networkType=~".+"} > 1800
+  and on(namespace, lease) leases_counts{phase="Pending"} > 0
+```
+
+### Alert: high delay rate
+
+```promql
+rate(lease_delays_total[15m]) > 0.5
+```
+
+### Alert: stale lease (older than 14 days)
+
+```promql
+lease_age_seconds > 86400 * 14
+```

--- a/pkg/controller/leases.go
+++ b/pkg/controller/leases.go
@@ -116,6 +116,15 @@ func getNetworksForPool(pool *v1.Pool) map[string]*v1.Network {
 	return networksInPool
 }
 
+func getNetworkType(network *v1.Network) string {
+	if network.ObjectMeta.Labels != nil {
+		if val, exists := network.ObjectMeta.Labels[v1.NetworkTypeLabel]; exists {
+			return val
+		}
+	}
+	return string(v1.NetworkTypeSingleTenant)
+}
+
 // getAvailableNetworks retrieves networks which are not owned by a lease
 func (l *LeaseReconciler) getAvailableNetworks(pool *v1.Pool, networkType v1.NetworkType) []*v1.Network {
 	networksInPool := getNetworksForPool(pool)
@@ -136,14 +145,7 @@ func (l *LeaseReconciler) getAvailableNetworks(pool *v1.Pool, networkType v1.Net
 			}
 		}
 
-		thisNetworkType := string(v1.NetworkTypeSingleTenant)
-		if network.ObjectMeta.Labels != nil {
-			if val, exists := network.ObjectMeta.Labels[v1.NetworkTypeLabel]; exists {
-				log.Printf("network found with NeworkTypeLabel: %s", val)
-				thisNetworkType = val
-			}
-		}
-		if thisNetworkType != string(networkType) {
+		if getNetworkType(network) != string(networkType) {
 			continue
 		}
 		if !hasOwner {
@@ -293,6 +295,7 @@ func (l *LeaseReconciler) triggerLeaseUpdates(ctx context.Context, networkType v
 
 func updateLeaseMetrics() {
 	LeaseCounts.Reset()
+	LeaseAgeSeconds.Reset()
 	for _, lease := range leases {
 		promLabels := make(prometheus.Labels)
 		promLabels["phase"] = string(lease.Status.Phase)
@@ -300,6 +303,70 @@ func updateLeaseMetrics() {
 		promLabels["namespace"] = lease.Namespace
 
 		LeaseCounts.With(promLabels).Inc()
+
+		poolName := ""
+		for _, ownerRef := range lease.OwnerReferences {
+			if ownerRef.Kind == "Pool" {
+				poolName = ownerRef.Name
+				break
+			}
+		}
+		LeaseAgeSeconds.With(prometheus.Labels{
+			"namespace":   lease.Namespace,
+			"lease":       lease.Name,
+			"pool":        poolName,
+			"networkType": string(lease.Spec.NetworkType),
+		}).Set(time.Since(lease.CreationTimestamp.Time).Seconds())
+	}
+
+	updateNetworkTypeMetrics()
+}
+
+func updateNetworkTypeMetrics() {
+	PoolNetworksAvailableByType.Reset()
+	PoolNetworksTotalByType.Reset()
+	NetworkLeaseCount.Reset()
+
+	networkLeaseCount := make(map[string]float64)
+	for _, lease := range leases {
+		for _, ownerRef := range lease.OwnerReferences {
+			if ownerRef.Kind == "Network" {
+				networkLeaseCount[ownerRef.Name]++
+			}
+		}
+	}
+
+	for _, pool := range pools {
+		totalByType := make(map[string]float64)
+		availByType := make(map[string]float64)
+
+		networksInPool := getNetworksForPool(pool)
+		for _, network := range networksInPool {
+			netType := getNetworkType(network)
+			totalByType[netType]++
+
+			count := networkLeaseCount[network.Name]
+			if count == 0 {
+				availByType[netType]++
+			}
+
+			NetworkLeaseCount.With(prometheus.Labels{
+				"namespace":   pool.Namespace,
+				"network":     network.Name,
+				"networkType": netType,
+				"pool":        pool.Name,
+			}).Set(count)
+		}
+
+		for netType, total := range totalByType {
+			promLabels := prometheus.Labels{
+				"namespace":   pool.Namespace,
+				"pool":        pool.Name,
+				"networkType": netType,
+			}
+			PoolNetworksTotalByType.With(promLabels).Set(total)
+			PoolNetworksAvailableByType.With(promLabels).Set(availByType[netType])
+		}
 	}
 }
 
@@ -468,6 +535,11 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	if len(lease.Status.Phase) == 0 {
 		lease.Status.Phase = v1.PHASE_PENDING
+		LeaseTransitionsTotal.With(prometheus.Labels{
+			"namespace":   lease.Namespace,
+			"networkType": string(lease.Spec.NetworkType),
+			"phase":       string(v1.PHASE_PENDING),
+		}).Inc()
 		lease.Status.Topology.Datacenter = "pending"
 		lease.Status.Topology.Datastore = "/pending/datastore/pending"
 		lease.Status.Topology.ComputeCluster = "/pending/host/pending"
@@ -574,6 +646,11 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	if len(lease.Status.Phase) == 0 {
 		log.Printf("setting lease %s status to %s", lease.Name, v1.PHASE_PENDING)
 		lease.Status.Phase = v1.PHASE_PENDING
+		LeaseTransitionsTotal.With(prometheus.Labels{
+			"namespace":   lease.Namespace,
+			"networkType": string(lease.Spec.NetworkType),
+			"phase":       string(v1.PHASE_PENDING),
+		}).Inc()
 
 		conditions.Set(lease, conditions.FalseCondition(
 			v1.LeaseConditionTypeFulfilled,
@@ -604,6 +681,10 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	// ensure that older leases get to finish getting their requests fulfilled before their Ci jobs timeout.
 	if shouldLeaseBeDelayed(lease) {
 		log.Printf("=========== lease %v is being delayed due to presence of higher priority leases ===========", lease.Name)
+		LeaseDelaysTotal.With(prometheus.Labels{
+			"namespace":   lease.Namespace,
+			"networkType": string(lease.Spec.NetworkType),
+		}).Inc()
 
 		conditions.Set(lease, conditions.TrueCondition(
 			v1.LeaseConditionTypeDelayed,
@@ -958,6 +1039,11 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	if poolsFulfilled && networksFulfilled {
 		lease.Status.Phase = v1.PHASE_FULFILLED
+		LeaseTransitionsTotal.With(prometheus.Labels{
+			"namespace":   lease.Namespace,
+			"networkType": string(lease.Spec.NetworkType),
+			"phase":       string(v1.PHASE_FULFILLED),
+		}).Inc()
 
 		conditions.Set(lease, conditions.TrueCondition(
 			v1.LeaseConditionTypeFulfilled,
@@ -970,6 +1056,11 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		))
 	} else {
 		lease.Status.Phase = v1.PHASE_PARTIAL
+		LeaseTransitionsTotal.With(prometheus.Labels{
+			"namespace":   lease.Namespace,
+			"networkType": string(lease.Spec.NetworkType),
+			"phase":       string(v1.PHASE_PARTIAL),
+		}).Inc()
 		conditions.Set(lease, conditions.FalseCondition(
 			v1.LeaseConditionTypePending,
 		))

--- a/pkg/controller/leases_test.go
+++ b/pkg/controller/leases_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/openshift-splat-team/vsphere-capacity-manager/pkg/apis/vspherecapacitymanager.splat.io/v1"
@@ -150,5 +151,237 @@ func TestDoesLeaseContainPortGroup(t *testing.T) {
 				t.Errorf("doesLeaseContainPortGroup() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGetNetworkType(t *testing.T) {
+	tests := []struct {
+		name     string
+		network  *v1.Network
+		expected string
+	}{
+		{
+			name: "returns single-tenant when no labels",
+			network: &v1.Network{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expected: "single-tenant",
+		},
+		{
+			name: "returns single-tenant when label missing",
+			network: &v1.Network{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"other": "value"},
+				},
+			},
+			expected: "single-tenant",
+		},
+		{
+			name: "returns multi-tenant from label",
+			network: &v1.Network{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.NetworkTypeLabel: "multi-tenant",
+					},
+				},
+			},
+			expected: "multi-tenant",
+		},
+		{
+			name: "returns disconnected from label",
+			network: &v1.Network{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1.NetworkTypeLabel: "disconnected",
+					},
+				},
+			},
+			expected: "disconnected",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getNetworkType(tt.network)
+			if got != tt.expected {
+				t.Errorf("getNetworkType() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestUpdateNetworkTypeMetrics(t *testing.T) {
+	dc := "dc1"
+	pod := "pod1"
+
+	oldPools := pools
+	oldNetworks := networks
+	oldLeases := leases
+	defer func() {
+		pools = oldPools
+		networks = oldNetworks
+		leases = oldLeases
+	}()
+
+	networks = map[string]*v1.Network{
+		"default/net-st-1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "net-st-1",
+				Namespace: "default",
+			},
+			Spec: v1.NetworkSpec{
+				PortGroupName:  "pg-100",
+				VlanId:         "100",
+				DatacenterName: &dc,
+				PodName:        &pod,
+			},
+		},
+		"default/net-st-2": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "net-st-2",
+				Namespace: "default",
+			},
+			Spec: v1.NetworkSpec{
+				PortGroupName:  "pg-101",
+				VlanId:         "101",
+				DatacenterName: &dc,
+				PodName:        &pod,
+			},
+		},
+		"default/net-mt-1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "net-mt-1",
+				Namespace: "default",
+				Labels: map[string]string{
+					v1.NetworkTypeLabel: "multi-tenant",
+				},
+			},
+			Spec: v1.NetworkSpec{
+				PortGroupName:  "pg-200",
+				VlanId:         "200",
+				DatacenterName: &dc,
+				PodName:        &pod,
+			},
+		},
+	}
+
+	pools = map[string]*v1.Pool{
+		"default/pool1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pool1",
+				Namespace: "default",
+			},
+			Spec: v1.PoolSpec{
+				FailureDomainSpec: v1.FailureDomainSpec{
+					VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+						Topology: configv1.VSpherePlatformTopology{
+							Networks: []string{"/dc1/network/pg-100", "/dc1/network/pg-101", "/dc1/network/pg-200"},
+						},
+					},
+				},
+				IBMPoolSpec: v1.IBMPoolSpec{Pod: pod},
+			},
+		},
+	}
+
+	leases = map[string]*v1.Lease{
+		"default/lease1": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "lease1",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{Kind: "Network", Name: "net-st-1"},
+				},
+			},
+			Spec: v1.LeaseSpec{
+				NetworkType: v1.NetworkTypeSingleTenant,
+			},
+			Status: v1.LeaseStatus{
+				Phase: v1.PHASE_FULFILLED,
+			},
+		},
+	}
+
+	updateNetworkTypeMetrics()
+
+	stTotal := testutil.ToFloat64(PoolNetworksTotalByType.WithLabelValues("default", "pool1", "single-tenant"))
+	if stTotal != 2 {
+		t.Errorf("expected single-tenant total = 2, got %v", stTotal)
+	}
+
+	stAvail := testutil.ToFloat64(PoolNetworksAvailableByType.WithLabelValues("default", "pool1", "single-tenant"))
+	if stAvail != 1 {
+		t.Errorf("expected single-tenant available = 1, got %v", stAvail)
+	}
+
+	mtTotal := testutil.ToFloat64(PoolNetworksTotalByType.WithLabelValues("default", "pool1", "multi-tenant"))
+	if mtTotal != 1 {
+		t.Errorf("expected multi-tenant total = 1, got %v", mtTotal)
+	}
+
+	mtAvail := testutil.ToFloat64(PoolNetworksAvailableByType.WithLabelValues("default", "pool1", "multi-tenant"))
+	if mtAvail != 1 {
+		t.Errorf("expected multi-tenant available = 1, got %v", mtAvail)
+	}
+
+	// Verify network_lease_count
+	stInUse := testutil.ToFloat64(NetworkLeaseCount.WithLabelValues("default", "net-st-1", "single-tenant", "pool1"))
+	if stInUse != 1 {
+		t.Errorf("expected net-st-1 lease count = 1, got %v", stInUse)
+	}
+
+	stFree := testutil.ToFloat64(NetworkLeaseCount.WithLabelValues("default", "net-st-2", "single-tenant", "pool1"))
+	if stFree != 0 {
+		t.Errorf("expected net-st-2 lease count = 0, got %v", stFree)
+	}
+
+	mtFree := testutil.ToFloat64(NetworkLeaseCount.WithLabelValues("default", "net-mt-1", "multi-tenant", "pool1"))
+	if mtFree != 0 {
+		t.Errorf("expected net-mt-1 lease count = 0, got %v", mtFree)
+	}
+}
+
+func TestUpdateLeaseMetrics(t *testing.T) {
+	oldLeases := leases
+	oldPools := pools
+	oldNetworks := networks
+	defer func() {
+		leases = oldLeases
+		pools = oldPools
+		networks = oldNetworks
+	}()
+
+	networks = make(map[string]*v1.Network)
+	pools = make(map[string]*v1.Pool)
+
+	now := metav1.Now()
+	leases = map[string]*v1.Lease{
+		"default/test-lease": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-lease",
+				Namespace:         "default",
+				CreationTimestamp: now,
+				OwnerReferences: []metav1.OwnerReference{
+					{Kind: "Pool", Name: "pool1"},
+				},
+			},
+			Spec: v1.LeaseSpec{
+				NetworkType: v1.NetworkTypeMultiTenant,
+			},
+			Status: v1.LeaseStatus{
+				Phase: v1.PHASE_FULFILLED,
+			},
+		},
+	}
+
+	updateLeaseMetrics()
+
+	count := testutil.ToFloat64(LeaseCounts.WithLabelValues("default", "multi-tenant", "Fulfilled"))
+	if count != 1 {
+		t.Errorf("expected lease count = 1, got %v", count)
+	}
+
+	age := testutil.ToFloat64(LeaseAgeSeconds.WithLabelValues("default", "test-lease", "pool1", "multi-tenant"))
+	if age < 0 || age > 5 {
+		t.Errorf("expected lease age near 0 seconds, got %v", age)
 	}
 }

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -28,7 +28,47 @@ var (
 
 	PoolNetworksAvailable = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pool_networks_available",
-		Help: "Number of currently used networks",
+		Help: "Number of available (not in use) networks per pool",
+	}, []string{"namespace", "pool"})
+
+	PoolNetworksTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pool_networks_total",
+		Help: "Total number of networks in a pool",
+	}, []string{"namespace", "pool"})
+
+	PoolNetworksAvailableByType = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pool_networks_available_by_type",
+		Help: "Number of available (not in use) networks per pool, broken down by network type",
+	}, []string{"namespace", "pool", "networkType"})
+
+	PoolNetworksTotalByType = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pool_networks_total_by_type",
+		Help: "Total number of networks per pool, broken down by network type",
+	}, []string{"namespace", "pool", "networkType"})
+
+	PoolVcpusUtilizationRatio = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pool_vcpus_utilization_ratio",
+		Help: "Ratio of vCPUs in use to total available (with overcommit) per pool",
+	}, []string{"namespace", "pool"})
+
+	PoolMemoryUtilizationRatio = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pool_memory_utilization_ratio",
+		Help: "Ratio of memory in use to total available per pool",
+	}, []string{"namespace", "pool"})
+
+	PoolNetworksUtilizationRatio = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pool_networks_utilization_ratio",
+		Help: "Ratio of networks in use to total available per pool",
+	}, []string{"namespace", "pool"})
+
+	PoolNoSchedule = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pool_no_schedule",
+		Help: "Whether pool has scheduling disabled (1=disabled, 0=enabled)",
+	}, []string{"namespace", "pool"})
+
+	PoolExcluded = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pool_excluded",
+		Help: "Whether pool is excluded from default scheduling (1=excluded, 0=included)",
 	}, []string{"namespace", "pool"})
 
 	LeasesInUse = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -40,8 +80,38 @@ var (
 		Name: "leases_counts",
 		Help: "Counts of active leases",
 	}, []string{"namespace", "networkType", "phase"})
+
+	LeaseAgeSeconds = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "lease_age_seconds",
+		Help: "Age of active leases in seconds since creation",
+	}, []string{"namespace", "lease", "pool", "networkType"})
+
+	LeaseTransitionsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "lease_transitions_total",
+		Help: "Total number of lease phase transitions",
+	}, []string{"namespace", "networkType", "phase"})
+
+	LeaseDelaysTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "lease_delays_total",
+		Help: "Total number of times leases have been delayed",
+	}, []string{"namespace", "networkType"})
+
+	NetworkLeaseCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "network_lease_count",
+		Help: "Number of leases currently using each network",
+	}, []string{"namespace", "network", "networkType", "pool"})
 )
 
 func InitMetrics() {
-	metrics.Registry.MustRegister(PoolMemoryAvailable, PoolMemoryTotal, PoolNetworksAvailable, PoolCpusAvailable, PoolCpusTotal, LeasesInUse, LeaseCounts)
+	metrics.Registry.MustRegister(
+		PoolMemoryAvailable, PoolMemoryTotal,
+		PoolNetworksAvailable, PoolNetworksTotal,
+		PoolNetworksAvailableByType, PoolNetworksTotalByType,
+		PoolCpusAvailable, PoolCpusTotal,
+		PoolVcpusUtilizationRatio, PoolMemoryUtilizationRatio, PoolNetworksUtilizationRatio,
+		PoolNoSchedule, PoolExcluded,
+		LeasesInUse, LeaseCounts,
+		LeaseAgeSeconds, LeaseTransitionsTotal, LeaseDelaysTotal,
+		NetworkLeaseCount,
+	)
 }

--- a/pkg/controller/pools.go
+++ b/pkg/controller/pools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 
 	generator "github.com/docker/docker/pkg/namesgenerator"
 	"github.com/prometheus/client_golang/prometheus"
@@ -104,19 +105,7 @@ func (l *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		pool.Status.Initialized = true
 	}
 
-	promLabels := prometheus.Labels{
-		"namespace": req.Namespace,
-		"pool":      req.Name,
-	}
-
 	pools[poolKey] = pool
-
-	PoolMemoryAvailable.With(promLabels).Set(float64(pool.Status.MemoryAvailable))
-	PoolMemoryTotal.With(promLabels).Set(float64(pool.Spec.Memory))
-	PoolNetworksAvailable.With(promLabels).Set(float64(pool.Status.NetworkAvailable))
-	PoolCpusAvailable.With(promLabels).Set(float64(pool.Status.VCpusAvailable))
-	PoolCpusTotal.With(promLabels).Set(float64(pool.Spec.VCpus))
-	LeasesInUse.With(promLabels).Set(float64(pool.Status.LeaseCount))
 
 	reconciledPools := reconcilePoolStates()
 	for _, reconciledPool := range reconciledPools {
@@ -128,6 +117,47 @@ func (l *PoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 			}
 		}
 	}
+
+	promLabels := prometheus.Labels{
+		"namespace": req.Namespace,
+		"pool":      req.Name,
+	}
+
+	PoolMemoryAvailable.With(promLabels).Set(float64(pool.Status.MemoryAvailable))
+	PoolMemoryTotal.With(promLabels).Set(float64(pool.Spec.Memory))
+	PoolNetworksAvailable.With(promLabels).Set(float64(pool.Status.NetworkAvailable))
+	PoolNetworksTotal.With(promLabels).Set(float64(len(pool.Spec.Topology.Networks)))
+	PoolCpusAvailable.With(promLabels).Set(float64(pool.Status.VCpusAvailable))
+	PoolCpusTotal.With(promLabels).Set(float64(pool.Spec.VCpus))
+	LeasesInUse.With(promLabels).Set(float64(pool.Status.LeaseCount))
+
+	overCommitRatio, err := strconv.ParseFloat(pool.Spec.OverCommitRatio, 64)
+	if err != nil {
+		overCommitRatio = 1.0
+	}
+	effectiveCpus := float64(pool.Spec.VCpus) * overCommitRatio
+	if effectiveCpus > 0 {
+		PoolVcpusUtilizationRatio.With(promLabels).Set((effectiveCpus - float64(pool.Status.VCpusAvailable)) / effectiveCpus)
+	}
+	if pool.Spec.Memory > 0 {
+		PoolMemoryUtilizationRatio.With(promLabels).Set(float64(pool.Spec.Memory-pool.Status.MemoryAvailable) / float64(pool.Spec.Memory))
+	}
+	networksTotal := float64(len(pool.Spec.Topology.Networks))
+	if networksTotal > 0 {
+		PoolNetworksUtilizationRatio.With(promLabels).Set((networksTotal - float64(pool.Status.NetworkAvailable)) / networksTotal)
+	}
+
+	noSchedule := float64(0)
+	if pool.Spec.NoSchedule {
+		noSchedule = 1
+	}
+	PoolNoSchedule.With(promLabels).Set(noSchedule)
+
+	excluded := float64(0)
+	if pool.Spec.Exclude {
+		excluded = 1
+	}
+	PoolExcluded.With(promLabels).Set(excluded)
 
 	return ctrl.Result{}, nil
 }

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint"
+)
+
+// CollectAndLint registers the provided Collector with a newly created pedantic
+// Registry. It then calls GatherAndLint with that Registry and with the
+// provided metricNames.
+func CollectAndLint(c prometheus.Collector, metricNames ...string) ([]promlint.Problem, error) {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return nil, fmt.Errorf("registering collector failed: %w", err)
+	}
+	return GatherAndLint(reg, metricNames...)
+}
+
+// GatherAndLint gathers all metrics from the provided Gatherer and checks them
+// with the linter in the promlint package. If any metricNames are provided,
+// only metrics with those names are checked.
+func GatherAndLint(g prometheus.Gatherer, metricNames ...string) ([]promlint.Problem, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return nil, fmt.Errorf("gathering metrics failed: %w", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+	return promlint.NewWithMetricFamilies(got).Lint()
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
@@ -1,0 +1,358 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides helpers to test code using the prometheus package
+// of client_golang.
+//
+// While writing unit tests to verify correct instrumentation of your code, it's
+// a common mistake to mostly test the instrumentation library instead of your
+// own code. Rather than verifying that a prometheus.Counter's value has changed
+// as expected or that it shows up in the exposition after registration, it is
+// in general more robust and more faithful to the concept of unit tests to use
+// mock implementations of the prometheus.Counter and prometheus.Registerer
+// interfaces that simply assert that the Add or Register methods have been
+// called with the expected arguments. However, this might be overkill in simple
+// scenarios. The ToFloat64 function is provided for simple inspection of a
+// single-value metric, but it has to be used with caution.
+//
+// End-to-end tests to verify all or larger parts of the metrics exposition can
+// be implemented with the CollectAndCompare or GatherAndCompare functions. The
+// most appropriate use is not so much testing instrumentation of your code, but
+// testing custom prometheus.Collector implementations and in particular whole
+// exporters, i.e. programs that retrieve telemetry data from a 3rd party source
+// and convert it into Prometheus metrics.
+//
+// In a similar pattern, CollectAndLint and GatherAndLint can be used to detect
+// metrics that have issues with their name, type, or metadata without being
+// necessarily invalid, e.g. a counter with a name missing the “_total” suffix.
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+
+	"github.com/davecgh/go-spew/spew"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/internal"
+)
+
+// ToFloat64 collects all Metrics from the provided Collector. It expects that
+// this results in exactly one Metric being collected, which must be a Gauge,
+// Counter, or Untyped. In all other cases, ToFloat64 panics. ToFloat64 returns
+// the value of the collected Metric.
+//
+// The Collector provided is typically a simple instance of Gauge or Counter, or
+// – less commonly – a GaugeVec or CounterVec with exactly one element. But any
+// Collector fulfilling the prerequisites described above will do.
+//
+// Use this function with caution. It is computationally very expensive and thus
+// not suited at all to read values from Metrics in regular code. This is really
+// only for testing purposes, and even for testing, other approaches are often
+// more appropriate (see this package's documentation).
+//
+// A clear anti-pattern would be to use a metric type from the prometheus
+// package to track values that are also needed for something else than the
+// exposition of Prometheus metrics. For example, you would like to track the
+// number of items in a queue because your code should reject queuing further
+// items if a certain limit is reached. It is tempting to track the number of
+// items in a prometheus.Gauge, as it is then easily available as a metric for
+// exposition, too. However, then you would need to call ToFloat64 in your
+// regular code, potentially quite often. The recommended way is to track the
+// number of items conventionally (in the way you would have done it without
+// considering Prometheus metrics) and then expose the number with a
+// prometheus.GaugeFunc.
+func ToFloat64(c prometheus.Collector) float64 {
+	var (
+		m      prometheus.Metric
+		mCount int
+		mChan  = make(chan prometheus.Metric)
+		done   = make(chan struct{})
+	)
+
+	go func() {
+		for m = range mChan {
+			mCount++
+		}
+		close(done)
+	}()
+
+	c.Collect(mChan)
+	close(mChan)
+	<-done
+
+	if mCount != 1 {
+		panic(fmt.Errorf("collected %d metrics instead of exactly 1", mCount))
+	}
+
+	pb := &dto.Metric{}
+	if err := m.Write(pb); err != nil {
+		panic(fmt.Errorf("error happened while collecting metrics: %w", err))
+	}
+	if pb.Gauge != nil {
+		return pb.Gauge.GetValue()
+	}
+	if pb.Counter != nil {
+		return pb.Counter.GetValue()
+	}
+	if pb.Untyped != nil {
+		return pb.Untyped.GetValue()
+	}
+	panic(fmt.Errorf("collected a non-gauge/counter/untyped metric: %s", pb))
+}
+
+// CollectAndCount registers the provided Collector with a newly created
+// pedantic Registry. It then calls GatherAndCount with that Registry and with
+// the provided metricNames. In the unlikely case that the registration or the
+// gathering fails, this function panics. (This is inconsistent with the other
+// CollectAnd… functions in this package and has historical reasons. Changing
+// the function signature would be a breaking change and will therefore only
+// happen with the next major version bump.)
+func CollectAndCount(c prometheus.Collector, metricNames ...string) int {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		panic(fmt.Errorf("registering collector failed: %w", err))
+	}
+	result, err := GatherAndCount(reg, metricNames...)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+// GatherAndCount gathers all metrics from the provided Gatherer and counts
+// them. It returns the number of metric children in all gathered metric
+// families together. If any metricNames are provided, only metrics with those
+// names are counted.
+func GatherAndCount(g prometheus.Gatherer, metricNames ...string) (int, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return 0, fmt.Errorf("gathering metrics failed: %w", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+
+	result := 0
+	for _, mf := range got {
+		result += len(mf.GetMetric())
+	}
+	return result, nil
+}
+
+// ScrapeAndCompare calls a remote exporter's endpoint which is expected to return some metrics in
+// plain text format. Then it compares it with the results that the `expected` would return.
+// If the `metricNames` is not empty it would filter the comparison only to the given metric names.
+func ScrapeAndCompare(url string, expected io.Reader, metricNames ...string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("scraping metrics failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("the scraping target returned a status code other than 200: %d",
+			resp.StatusCode)
+	}
+
+	scraped, err := convertReaderToMetricFamily(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	wanted, err := convertReaderToMetricFamily(expected)
+	if err != nil {
+		return err
+	}
+
+	return compareMetricFamilies(scraped, wanted, metricNames...)
+}
+
+// CollectAndCompare registers the provided Collector with a newly created
+// pedantic Registry. It then calls GatherAndCompare with that Registry and with
+// the provided metricNames.
+func CollectAndCompare(c prometheus.Collector, expected io.Reader, metricNames ...string) error {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return fmt.Errorf("registering collector failed: %w", err)
+	}
+	return GatherAndCompare(reg, expected, metricNames...)
+}
+
+// GatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+func GatherAndCompare(g prometheus.Gatherer, expected io.Reader, metricNames ...string) error {
+	return TransactionalGatherAndCompare(prometheus.ToTransactionalGatherer(g), expected, metricNames...)
+}
+
+// TransactionalGatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+func TransactionalGatherAndCompare(g prometheus.TransactionalGatherer, expected io.Reader, metricNames ...string) error {
+	got, done, err := g.Gather()
+	defer done()
+	if err != nil {
+		return fmt.Errorf("gathering metrics failed: %w", err)
+	}
+
+	wanted, err := convertReaderToMetricFamily(expected)
+	if err != nil {
+		return err
+	}
+
+	return compareMetricFamilies(got, wanted, metricNames...)
+}
+
+// convertReaderToMetricFamily would read from a io.Reader object and convert it to a slice of
+// dto.MetricFamily.
+func convertReaderToMetricFamily(reader io.Reader) ([]*dto.MetricFamily, error) {
+	var tp expfmt.TextParser
+	notNormalized, err := tp.TextToMetricFamilies(reader)
+	if err != nil {
+		return nil, fmt.Errorf("converting reader to metric families failed: %w", err)
+	}
+
+	// The text protocol handles empty help fields inconsistently. When
+	// encoding, any non-nil value, include the empty string, produces a
+	// "# HELP" line. But when decoding, the help field is only set to a
+	// non-nil value if the "# HELP" line contains a non-empty value.
+	//
+	// Because metrics in a registry always have non-nil help fields, populate
+	// any nil help fields in the parsed metrics with the empty string so that
+	// when we compare text encodings, the results are consistent.
+	for _, metric := range notNormalized {
+		if metric.Help == nil {
+			metric.Help = proto.String("")
+		}
+	}
+
+	return internal.NormalizeMetricFamilies(notNormalized), nil
+}
+
+// compareMetricFamilies would compare 2 slices of metric families, and optionally filters both of
+// them to the `metricNames` provided.
+func compareMetricFamilies(got, expected []*dto.MetricFamily, metricNames ...string) error {
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+		expected = filterMetrics(expected, metricNames)
+	}
+
+	return compare(got, expected)
+}
+
+// compare encodes both provided slices of metric families into the text format,
+// compares their string message, and returns an error if they do not match.
+// The error contains the encoded text of both the desired and the actual
+// result.
+func compare(got, want []*dto.MetricFamily) error {
+	var gotBuf, wantBuf bytes.Buffer
+	enc := expfmt.NewEncoder(&gotBuf, expfmt.FmtText)
+	for _, mf := range got {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding gathered metrics failed: %w", err)
+		}
+	}
+	enc = expfmt.NewEncoder(&wantBuf, expfmt.FmtText)
+	for _, mf := range want {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding expected metrics failed: %w", err)
+		}
+	}
+	if diffErr := diff(wantBuf, gotBuf); diffErr != "" {
+		return fmt.Errorf(diffErr)
+	}
+	return nil
+}
+
+// diff returns a diff of both values as long as both are of the same type and
+// are a struct, map, slice, array or string. Otherwise it returns an empty string.
+func diff(expected, actual interface{}) string {
+	if expected == nil || actual == nil {
+		return ""
+	}
+
+	et, ek := typeAndKind(expected)
+	at, _ := typeAndKind(actual)
+	if et != at {
+		return ""
+	}
+
+	if ek != reflect.Struct && ek != reflect.Map && ek != reflect.Slice && ek != reflect.Array && ek != reflect.String {
+		return ""
+	}
+
+	var e, a string
+	c := spew.ConfigState{
+		Indent:                  " ",
+		DisablePointerAddresses: true,
+		DisableCapacities:       true,
+		SortKeys:                true,
+	}
+	if et != reflect.TypeOf("") {
+		e = c.Sdump(expected)
+		a = c.Sdump(actual)
+	} else {
+		e = reflect.ValueOf(expected).String()
+		a = reflect.ValueOf(actual).String()
+	}
+
+	diff, _ := internal.GetUnifiedDiffString(internal.UnifiedDiff{
+		A:        internal.SplitLines(e),
+		B:        internal.SplitLines(a),
+		FromFile: "metric output does not match expectation; want",
+		FromDate: "",
+		ToFile:   "got:",
+		ToDate:   "",
+		Context:  1,
+	})
+
+	if diff == "" {
+		return ""
+	}
+
+	return "\n\nDiff:\n" + diff
+}
+
+// typeAndKind returns the type and kind of the given interface{}
+func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
+	t := reflect.TypeOf(v)
+	k := t.Kind()
+
+	if k == reflect.Ptr {
+		t = t.Elem()
+		k = t.Kind()
+	}
+	return t, k
+}
+
+func filterMetrics(metrics []*dto.MetricFamily, names []string) []*dto.MetricFamily {
+	var filtered []*dto.MetricFamily
+	for _, m := range metrics {
+		for _, name := range names {
+			if m.GetName() == name {
+				filtered = append(filtered, m)
+				break
+			}
+		}
+	}
+	return filtered
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -554,6 +554,7 @@ github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/collectors
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
+github.com/prometheus/client_golang/prometheus/testutil
 github.com/prometheus/client_golang/prometheus/testutil/promlint
 github.com/prometheus/client_golang/prometheus/testutil/promlint/validations
 # github.com/prometheus/client_model v0.5.0


### PR DESCRIPTION
…ilization, and lease lifecycle

Adds 13 new Prometheus metrics to improve observability:
- Network counts by type (pool_networks_available_by_type, pool_networks_total_by_type)
- Pool networks total (pool_networks_total)
- Pool utilization ratios (pool_vcpus_utilization_ratio, pool_memory_utilization_ratio, pool_networks_utilization_ratio)
- Pool scheduling state (pool_no_schedule, pool_excluded)
- Lease age tracking (lease_age_seconds)
- Lease lifecycle counters (lease_transitions_total, lease_delays_total)
- Per-network lease sharing (network_lease_count)

Also extracts getNetworkType() helper, fixes misleading help text on pool_networks_available, and adds unit tests for the new functions.