### PR TITLE
Fix/skip status update when no networks

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,11 +7,11 @@ jobs:
   image:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.22'
     - name: image
       uses: redhat-actions/buildah-build@v2
       id: build-image

--- a/.github/workflows/gomod.yml
+++ b/.github/workflows/gomod.yml
@@ -10,10 +10,10 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.22'
     - name: verify
       run: go mod verify

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -11,11 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: false
-      - name: Install deps
-        run: go install github.com/onsi/ginkgo/v2/ginkgo
-      - name: Install envtest
-        run: go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-      - name: Run Ginkgo Tests
+      - name: Run Tests
         run: "make test"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SHELL = /usr/bin/env bash -o pipefail
 
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 CONTROLLER_GEN = go run ${PROJECT_DIR}/vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
-ENVTEST = go run ${PROJECT_DIR}/vendor/sigs.k8s.io/controller-runtime/tools/setup-envtest
+ENVTEST = go run sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.19
 GINKGO = go run ${PROJECT_DIR}/vendor/github.com/onsi/ginkgo/v2/ginkgo
 GOLANGCI_LINT = go run ${PROJECT_DIR}/vendor/github.com/golangci/golangci-lint/cmd/golangci-lint
 

--- a/pkg/controller/leases.go
+++ b/pkg/controller/leases.go
@@ -125,6 +125,27 @@ func getNetworkType(network *v1.Network) string {
 	return string(v1.NetworkTypeSingleTenant)
 }
 
+// poolMissingNetworks returns the name of the first pool that has zero networks
+// assigned in the lease's OwnerReferences, and true. If every pool has at least
+// one network, it returns ("", false).
+func poolMissingNetworks(lease *v1.Lease, assignedPools []*v1.Pool) (string, bool) {
+	for _, pool := range assignedPools {
+		poolNetworksMap := getNetworksForPool(pool)
+		count := 0
+		for _, ownerRef := range lease.OwnerReferences {
+			if ownerRef.Kind == "Network" {
+				if _, exists := poolNetworksMap[ownerRef.Name]; exists {
+					count++
+				}
+			}
+		}
+		if count == 0 {
+			return pool.Name, true
+		}
+	}
+	return "", false
+}
+
 // getAvailableNetworks retrieves networks which are not owned by a lease
 func (l *LeaseReconciler) getAvailableNetworks(pool *v1.Pool, networkType v1.NetworkType) []*v1.Network {
 	networksInPool := getNetworksForPool(pool)
@@ -958,6 +979,18 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				log.Printf("error generating env vars: %v", err)
 			}
 		}
+	}
+
+	// CRD validation requires MinItems=1 for topology.networks.
+	// If any pool has zero assigned networks, skip the status update to avoid rejection.
+	if poolName, missing := poolMissingNetworks(lease, assignedPools); missing {
+		log.Printf("pool %s has no networks assigned for lease %s, saving owner refs and requeuing", poolName, lease.Name)
+		err = l.Client.Update(ctx, lease)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("error updating lease owner references: %v", err)
+		}
+		updateLeaseMetrics()
+		return ctrl.Result{RequeueAfter: LEASE_PARTIAL_RETRY_INTERVAL}, nil
 	}
 
 	// Populate poolInfo array with FailureDomainSpec from each assigned pool

--- a/pkg/controller/leases_test.go
+++ b/pkg/controller/leases_test.go
@@ -558,3 +558,155 @@ func TestUpdateLeaseMetrics(t *testing.T) {
 		t.Errorf("expected lease age near 0 seconds, got %v", age)
 	}
 }
+
+func TestPoolMissingNetworks(t *testing.T) {
+	dc := "dc1"
+	pod := "pod1"
+
+	net1 := &v1.Network{
+		ObjectMeta: metav1.ObjectMeta{Name: "net-1"},
+		TypeMeta:   metav1.TypeMeta{Kind: "Network"},
+		Spec: v1.NetworkSpec{
+			VlanId:         "100",
+			DatacenterName: &dc,
+			PodName:        &pod,
+			PortGroupName:  "pg-100",
+		},
+	}
+
+	net2 := &v1.Network{
+		ObjectMeta: metav1.ObjectMeta{Name: "net-2"},
+		TypeMeta:   metav1.TypeMeta{Kind: "Network"},
+		Spec: v1.NetworkSpec{
+			VlanId:         "200",
+			DatacenterName: &dc,
+			PodName:        &pod,
+			PortGroupName:  "pg-200",
+		},
+	}
+
+	poolA := &v1.Pool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-a"},
+		Spec: v1.PoolSpec{
+			FailureDomainSpec: v1.FailureDomainSpec{
+				VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+					Topology: configv1.VSpherePlatformTopology{
+						Networks: []string{"/dc1/network/pg-100"},
+					},
+				},
+			},
+			IBMPoolSpec: v1.IBMPoolSpec{Pod: pod},
+		},
+	}
+
+	poolB := &v1.Pool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-b"},
+		Spec: v1.PoolSpec{
+			FailureDomainSpec: v1.FailureDomainSpec{
+				VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+					Topology: configv1.VSpherePlatformTopology{
+						Networks: []string{"/dc1/network/pg-200"},
+					},
+				},
+			},
+			IBMPoolSpec: v1.IBMPoolSpec{Pod: pod},
+		},
+	}
+
+	cleanup := setupTestNetworks(map[string]*v1.Network{
+		"net-1": net1,
+		"net-2": net2,
+	})
+	defer cleanup()
+
+	tests := []struct {
+		name         string
+		lease        *v1.Lease
+		pools        []*v1.Pool
+		wantMissing  bool
+		wantPoolName string
+	}{
+		{
+			name: "returns false when all pools have networks",
+			lease: &v1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Pool", Name: "pool-a"},
+						{Kind: "Network", Name: "net-1"},
+						{Kind: "Pool", Name: "pool-b"},
+						{Kind: "Network", Name: "net-2"},
+					},
+				},
+			},
+			pools:       []*v1.Pool{poolA, poolB},
+			wantMissing: false,
+		},
+		{
+			name: "returns true when a pool has no networks",
+			lease: &v1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Pool", Name: "pool-a"},
+						{Kind: "Pool", Name: "pool-b"},
+						{Kind: "Network", Name: "net-1"},
+					},
+				},
+			},
+			pools:        []*v1.Pool{poolA, poolB},
+			wantMissing:  true,
+			wantPoolName: "pool-b",
+		},
+		{
+			name: "returns true when no networks assigned at all",
+			lease: &v1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Pool", Name: "pool-a"},
+					},
+				},
+			},
+			pools:        []*v1.Pool{poolA},
+			wantMissing:  true,
+			wantPoolName: "pool-a",
+		},
+		{
+			name: "returns false with single pool that has a network",
+			lease: &v1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Pool", Name: "pool-a"},
+						{Kind: "Network", Name: "net-1"},
+					},
+				},
+			},
+			pools:       []*v1.Pool{poolA},
+			wantMissing: false,
+		},
+		{
+			name: "ignores networks not in pool topology",
+			lease: &v1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{Kind: "Pool", Name: "pool-a"},
+						{Kind: "Network", Name: "net-2"},
+					},
+				},
+			},
+			pools:        []*v1.Pool{poolA},
+			wantMissing:  true,
+			wantPoolName: "pool-a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			poolName, missing := poolMissingNetworks(tt.lease, tt.pools)
+			if missing != tt.wantMissing {
+				t.Errorf("poolMissingNetworks() missing = %v, want %v", missing, tt.wantMissing)
+			}
+			if tt.wantMissing && poolName != tt.wantPoolName {
+				t.Errorf("poolMissingNetworks() poolName = %v, want %v", poolName, tt.wantPoolName)
+			}
+		})
+	}
+}

--- a/test/leases_test.go
+++ b/test/leases_test.go
@@ -370,7 +370,7 @@ var _ = Describe("Lease management", func() {
 			})
 			By("waiting for the lease to be deleted", func() {
 				Eventually(func() bool {
-					return k8sClient.Get(ctx, client.ObjectKeyFromObject(lease), lease) == nil
+					return k8sClient.Get(ctx, client.ObjectKeyFromObject(lease), lease) != nil
 				}).Should(BeTrue())
 			})
 		})
@@ -481,7 +481,7 @@ var _ = Describe("Lease management", func() {
 			})
 			By("waiting for the lease to be deleted", func() {
 				Eventually(func() bool {
-					return k8sClient.Get(ctx, client.ObjectKeyFromObject(lease), lease) == nil
+					return k8sClient.Get(ctx, client.ObjectKeyFromObject(lease), lease) != nil
 				}).Should(BeTrue())
 			})
 		})
@@ -552,7 +552,10 @@ var _ = Describe("Lease management", func() {
 			})
 			By("waiting for the lease to be deleted", func() {
 				Eventually(func() bool {
-					return k8sClient.Get(ctx, client.ObjectKeyFromObject(lease1), lease1) == nil
+					if k8sClient.Get(ctx, client.ObjectKeyFromObject(lease1), lease1) == nil {
+						return false
+					}
+					return k8sClient.Get(ctx, client.ObjectKeyFromObject(lease2), lease2) != nil
 				}).Should(BeTrue())
 			})
 		})
@@ -657,7 +660,7 @@ var _ = Describe("Lease management", func() {
 			})
 			By("waiting for the lease to be deleted", func() {
 				Eventually(func() bool {
-					return k8sClient.Get(ctx, client.ObjectKeyFromObject(lease1), lease1) == nil
+					return k8sClient.Get(ctx, client.ObjectKeyFromObject(lease1), lease1) != nil
 				}).Should(BeTrue())
 			})
 		})
@@ -757,16 +760,16 @@ var _ = Describe("Lease management", func() {
 			})
 			By("waiting for the lease to be deleted", func() {
 				Eventually(func() bool {
-					return k8sClient.Get(ctx, client.ObjectKeyFromObject(lease3), lease3) == nil
+					return k8sClient.Get(ctx, client.ObjectKeyFromObject(lease3), lease3) != nil
 				}).Should(BeTrue())
 			})
 		})
 
-		// Now wait for lease 2 to now be fulfilled
+		// Now wait for testLease to be fulfilled
 		By("waiting for leases to be fulfilled", func() {
 			Eventually(func() bool {
 				_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(testLease), testLease)
-				return lease2.Status.Phase == v1.PHASE_FULFILLED
+				return testLease.Status.Phase == v1.PHASE_FULFILLED
 			}).Should(BeTrue())
 		})
 
@@ -779,16 +782,13 @@ var _ = Describe("Lease management", func() {
 			})
 			By("waiting for the lease to be deleted", func() {
 				Eventually(func() bool {
-					lease := k8sClient.Get(ctx, client.ObjectKeyFromObject(lease1), lease1)
-					if lease != nil {
+					if k8sClient.Get(ctx, client.ObjectKeyFromObject(lease1), lease1) == nil {
 						return false
 					}
-					lease = k8sClient.Get(ctx, client.ObjectKeyFromObject(lease2), lease2)
-					if lease != nil {
+					if k8sClient.Get(ctx, client.ObjectKeyFromObject(lease2), lease2) == nil {
 						return false
 					}
-
-					return k8sClient.Get(ctx, client.ObjectKeyFromObject(lease1), lease1) == nil
+					return k8sClient.Get(ctx, client.ObjectKeyFromObject(testLease), testLease) != nil
 				}).Should(BeTrue())
 			})
 		})


### PR DESCRIPTION
When no networks of the requested type are available, the reconciler
was writing status.poolInfo with empty topology.networks, which the
CRD schema rejects (MinItems=1). This caused an infinite requeue loop
with noisy reconciler errors.

Now detect the zero-networks case before building poolInfo and return
early with RequeueAfter, persisting only the owner references.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Integration tests had inverted k8sClient.Get() checks in cleanup blocks —
returning true when objects still existed instead of when deleted, causing
leaked leases between tests. Also fixed a wrong variable check (lease1
instead of testLease) and a wrong phase check (lease2 instead of testLease).
Updated CI workflows to Go 1.22 and latest action versions.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
