### PR TITLE
fix: remove labeled/unlabeled triggers from CI workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,7 +2,7 @@ name: build
 
 on:
   pull_request:
-    types: [opened, labeled, unlabeled, synchronize]
+    types: [opened, synchronize, reopened]
 jobs:
   image:
     runs-on: ubuntu-latest

--- a/.github/workflows/gomod.yml
+++ b/.github/workflows/gomod.yml
@@ -5,7 +5,7 @@ name: vendor
 
 on:
   pull_request:
-    types: [opened, labeled, unlabeled, synchronize]
+    types: [opened, synchronize, reopened]
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,7 +1,7 @@
 name: lint
 on:
   pull_request:
-    types: [opened, labeled, unlabeled, synchronize]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,7 +1,7 @@
 name: test
 on:
   pull_request:
-    types: [opened, labeled, unlabeled, synchronize]
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Removes `labeled` and `unlabeled` event types from all 4 GitHub Actions workflow triggers
- Prow's label activity (lgtm, approved, jira/*, etc.) was causing redundant workflow runs that fail on every label change
- Workflows now only trigger on `opened`, `synchronize`, and `reopened` — actual code changes

## Test plan
- [ ] Open a PR and verify workflows run on push
- [ ] Add a label via Prow (`/hold`, `/lgtm`) and verify workflows do **not** re-trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)