### PR TITLE
SPLAT-2238: Added new vcenters field in lease to limit max number of vCenters

### DIFF
--- a/config/crd/bases/vspherecapacitymanager.splat.io_leases.yaml
+++ b/config/crd/bases/vspherecapacitymanager.splat.io_leases.yaml
@@ -131,6 +131,15 @@ spec:
                       type: string
                   type: object
                 type: array
+              vcenters:
+                description: 'VCenters is the maximum number of distinct vCenters
+                  (identified by Server FQDN) to use when fulfilling this lease. When
+                  0 or unset, no limit is applied. This acts as a cap on vcenter diversity
+                  across all assigned pools. For example, a lease with pools: 4 and
+                  vcenters: 3 will assign 4 pools but draw them from at most 3 distinct
+                  vCenters.'
+                minimum: 0
+                type: integer
               vcpus:
                 description: VCpus is the number of virtual CPUs allocated for this
                   lease

--- a/pkg/apis/vspherecapacitymanager.splat.io/v1/leases_types.go
+++ b/pkg/apis/vspherecapacitymanager.splat.io/v1/leases_types.go
@@ -80,6 +80,14 @@ type LeaseSpec struct {
 	// +kubebuilder:default=1
 	// +optional
 	Pools int `json:"pools,omitempty"`
+	// VCenters is the maximum number of distinct vCenters (identified by Server FQDN)
+	// to use when fulfilling this lease. When 0 or unset, no limit is applied.
+	// This acts as a cap on vcenter diversity across all assigned pools.
+	// For example, a lease with pools: 4 and vcenters: 3 will assign 4 pools but
+	// draw them from at most 3 distinct vCenters.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	VCenters int `json:"vcenters,omitempty"`
 	// Storage is the amount of storage in GB allocated for this lease
 	// +optional
 	Storage int `json:"storage,omitempty"`

--- a/pkg/apis/vspherecapacitymanager.splat.io/v1/leases_types_test.go
+++ b/pkg/apis/vspherecapacitymanager.splat.io/v1/leases_types_test.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestLeaseVCentersValidation tests the validation marker for the VCenters field
+// The actual validation happens in the CRD via kubebuilder:validation:Minimum=0
+// These tests document expected behavior when creating/updating Lease objects
+func TestLeaseVCentersValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		vcenters    int
+		expectValid bool
+		description string
+	}{
+		{
+			name:        "zero vcenters is valid (no limit)",
+			vcenters:    0,
+			expectValid: true,
+			description: "When vcenters is 0 or unset, no vcenter limit is applied",
+		},
+		{
+			name:        "positive vcenters is valid",
+			vcenters:    1,
+			expectValid: true,
+			description: "Positive vcenter values are valid",
+		},
+		{
+			name:        "multiple vcenters is valid",
+			vcenters:    3,
+			expectValid: true,
+			description: "Multiple vcenters can be specified",
+		},
+		{
+			name:        "large vcenters value is valid",
+			vcenters:    100,
+			expectValid: true,
+			description: "Large positive values are valid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lease := &Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-lease",
+					Namespace: "default",
+				},
+				Spec: LeaseSpec{
+					VCpus:    16,
+					Memory:   32,
+					Pools:    2,
+					VCenters: tt.vcenters,
+				},
+			}
+
+			// Marshal to JSON to ensure the field is serializable
+			_, err := json.Marshal(lease)
+			if err != nil && tt.expectValid {
+				t.Errorf("Expected valid lease to marshal successfully, got error: %v", err)
+			}
+
+			// Verify the field value is set correctly
+			if lease.Spec.VCenters != tt.vcenters {
+				t.Errorf("Expected VCenters=%d, got %d", tt.vcenters, lease.Spec.VCenters)
+			}
+		})
+	}
+}
+
+// TestLeaseVCentersDefaultValue tests that VCenters defaults to 0 when unset
+func TestLeaseVCentersDefaultValue(t *testing.T) {
+	lease := &Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-lease",
+			Namespace: "default",
+		},
+		Spec: LeaseSpec{
+			VCpus:  16,
+			Memory: 32,
+		},
+	}
+
+	// When VCenters is not explicitly set, it should default to 0
+	if lease.Spec.VCenters != 0 {
+		t.Errorf("Expected default VCenters=0, got %d", lease.Spec.VCenters)
+	}
+}
+
+// TestLeaseVCentersWithPoolsField tests the interaction between Pools and VCenters
+func TestLeaseVCentersWithPoolsField(t *testing.T) {
+	tests := []struct {
+		name        string
+		pools       int
+		vcenters    int
+		description string
+	}{
+		{
+			name:        "vcenters equals pools",
+			pools:       3,
+			vcenters:    3,
+			description: "Each pool can be on a different vcenter",
+		},
+		{
+			name:        "vcenters less than pools",
+			pools:       4,
+			vcenters:    2,
+			description: "Pools must be distributed across at most 2 vcenters",
+		},
+		{
+			name:        "vcenters greater than pools",
+			pools:       2,
+			vcenters:    5,
+			description: "More vcenters allowed than pools needed (acts as cap)",
+		},
+		{
+			name:        "vcenters zero with multiple pools",
+			pools:       5,
+			vcenters:    0,
+			description: "No vcenter limit - pools can span any number of vcenters",
+		},
+		{
+			name:        "single pool single vcenter",
+			pools:       1,
+			vcenters:    1,
+			description: "Simple case - one pool on one vcenter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lease := &Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-lease",
+					Namespace: "default",
+				},
+				Spec: LeaseSpec{
+					VCpus:    16,
+					Memory:   32,
+					Pools:    tt.pools,
+					VCenters: tt.vcenters,
+				},
+			}
+
+			// Verify both fields are set correctly
+			if lease.Spec.Pools != tt.pools {
+				t.Errorf("Expected Pools=%d, got %d", tt.pools, lease.Spec.Pools)
+			}
+			if lease.Spec.VCenters != tt.vcenters {
+				t.Errorf("Expected VCenters=%d, got %d", tt.vcenters, lease.Spec.VCenters)
+			}
+
+			// Document behavior when vcenters is 0
+			if tt.vcenters == 0 {
+				// When VCenters is 0, there should be no vcenter limit enforced
+				// This is the default behavior - pools can be assigned from any vcenters
+				if lease.Spec.VCenters != 0 {
+					t.Error("VCenters should be 0 to indicate no limit")
+				}
+			}
+		})
+	}
+}
+
+// TestLeaseVCentersJSONSerialization tests JSON marshaling/unmarshaling
+func TestLeaseVCentersJSONSerialization(t *testing.T) {
+	original := &Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-lease",
+			Namespace: "default",
+		},
+		Spec: LeaseSpec{
+			VCpus:    16,
+			Memory:   32,
+			Pools:    3,
+			VCenters: 2,
+		},
+	}
+
+	// Marshal to JSON
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Failed to marshal lease: %v", err)
+	}
+
+	// Unmarshal back
+	var unmarshaled Lease
+	if err := json.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal lease: %v", err)
+	}
+
+	// Verify VCenters field is preserved
+	if unmarshaled.Spec.VCenters != original.Spec.VCenters {
+		t.Errorf("VCenters field not preserved after marshal/unmarshal: got %d, want %d",
+			unmarshaled.Spec.VCenters, original.Spec.VCenters)
+	}
+}
+
+// TestLeaseVCentersOmitEmpty tests that VCenters with value 0 is handled correctly
+func TestLeaseVCentersOmitEmpty(t *testing.T) {
+	lease := &Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-lease",
+			Namespace: "default",
+		},
+		Spec: LeaseSpec{
+			VCpus:    16,
+			Memory:   32,
+			VCenters: 0,
+		},
+	}
+
+	data, err := json.Marshal(lease)
+	if err != nil {
+		t.Fatalf("Failed to marshal lease: %v", err)
+	}
+
+	// VCenters is marked as omitempty, so when it's 0 it may be omitted from JSON
+	// But when unmarshaled, it should still be 0
+	var unmarshaled Lease
+	if err := json.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("Failed to unmarshal lease: %v", err)
+	}
+
+	// Even if omitted in JSON, the zero value should be preserved
+	if unmarshaled.Spec.VCenters != 0 {
+		t.Errorf("Expected VCenters=0 after unmarshal, got %d", unmarshaled.Spec.VCenters)
+	}
+}

--- a/pkg/controller/leases.go
+++ b/pkg/controller/leases.go
@@ -768,10 +768,29 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			}
 		}
 
+		// Enforce the vCenters cap: if the lease specifies a maximum number of distinct
+		// vCenters and we have already reached that limit, restrict future pool assignments
+		// to the vCenters already in use.
+		var excludedVCenters map[string]bool
+		if lease.Spec.VCenters > 0 {
+			vcentersInUse := utils.GetVCentersInUse(assignedPools)
+			log.Printf("Lease %s has vcenters cap %d, currently using %d vcenters: %v", lease.Name, lease.Spec.VCenters, len(vcentersInUse), vcentersInUse)
+			if len(vcentersInUse) >= lease.Spec.VCenters {
+				// Cap reached — only allow pools from vCenters already in use
+				excludedVCenters = make(map[string]bool)
+				for _, p := range updatedPools {
+					srv := p.Spec.Server
+					if srv != "" && !vcentersInUse[srv] {
+						excludedVCenters[srv] = true
+					}
+				}
+			}
+		}
+
 		log.Printf("Attempting to assign pool %d/%d for lease %s, %d pools available after filtering", len(assignedPools)+1, requiredPools, lease.Name, len(availablePools))
 		log.Printf("Lease %s currently has %d owner references before GetPoolWithStrategy", lease.Name, len(lease.OwnerReferences))
 
-		pool, err := utils.GetPoolWithStrategy(lease, availablePools, v1.RESOURCE_ALLOCATION_STRATEGY_UNDERUTILIZED)
+		pool, err := utils.GetPoolWithStrategy(lease, availablePools, v1.RESOURCE_ALLOCATION_STRATEGY_UNDERUTILIZED, excludedVCenters)
 		if err != nil {
 			// If we already have some pools assigned, mark as partial
 			if len(assignedPools) > 0 {

--- a/pkg/controller/leases.go
+++ b/pkg/controller/leases.go
@@ -778,7 +778,7 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			if len(vcentersInUse) >= lease.Spec.VCenters {
 				// Cap reached — only allow pools from vCenters already in use
 				excludedVCenters = make(map[string]bool)
-				for _, p := range updatedPools {
+				for _, p := range availablePools {
 					srv := p.Spec.Server
 					if srv != "" && !vcentersInUse[srv] {
 						excludedVCenters[srv] = true

--- a/pkg/controller/leases_test.go
+++ b/pkg/controller/leases_test.go
@@ -57,10 +57,10 @@ func TestDoesLeaseContainPortGroup(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		lease    *v1.Lease
-		network  *v1.Network
-		want     bool
+		name    string
+		lease   *v1.Lease
+		network *v1.Network
+		want    bool
 	}{
 		{
 			name: "returns false when lease has no owner references",
@@ -706,6 +706,280 @@ func TestPoolMissingNetworks(t *testing.T) {
 			}
 			if tt.wantMissing && poolName != tt.wantPoolName {
 				t.Errorf("poolMissingNetworks() poolName = %v, want %v", poolName, tt.wantPoolName)
+			}
+		})
+	}
+}
+
+// TestLeaseVCentersCapEnforcement tests that the VCenters field properly caps vcenter diversity
+func TestLeaseVCentersCapEnforcement(t *testing.T) {
+	tests := []struct {
+		name             string
+		leaseVCenters    int
+		assignedPools    []*v1.Pool
+		expectExclusions bool
+		expectedExcluded map[string]bool
+	}{
+		{
+			name:          "no cap when VCenters is 0",
+			leaseVCenters: 0,
+			assignedPools: []*v1.Pool{
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+					},
+				},
+			},
+			expectExclusions: false,
+			expectedExcluded: nil,
+		},
+		{
+			name:             "no cap when VCenters not set and no pools assigned yet",
+			leaseVCenters:    0,
+			assignedPools:    []*v1.Pool{},
+			expectExclusions: false,
+			expectedExcluded: nil,
+		},
+		{
+			name:          "no exclusions when under cap",
+			leaseVCenters: 3,
+			assignedPools: []*v1.Pool{
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+					},
+				},
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+					},
+				},
+			},
+			expectExclusions: false,
+			expectedExcluded: nil,
+		},
+		{
+			name:          "exclusions when at cap",
+			leaseVCenters: 2,
+			assignedPools: []*v1.Pool{
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+					},
+				},
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+					},
+				},
+			},
+			expectExclusions: true,
+			expectedExcluded: map[string]bool{
+				// Any vcenter not in the assigned pools should be excluded
+				"vcenter3.example.com": true,
+			},
+		},
+		{
+			name:          "allows same vcenters when cap reached",
+			leaseVCenters: 1,
+			assignedPools: []*v1.Pool{
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+					},
+				},
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+					},
+				},
+			},
+			expectExclusions: true,
+			expectedExcluded: map[string]bool{
+				// vcenter1 is allowed (in use), all others excluded
+				"vcenter2.example.com": true,
+				"vcenter3.example.com": true,
+			},
+		},
+		{
+			name:          "handles pools with empty server field",
+			leaseVCenters: 1,
+			assignedPools: []*v1.Pool{
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "",
+							},
+						},
+					},
+				},
+			},
+			expectExclusions: false,
+			expectedExcluded: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the controller logic for computing excluded vcenters
+			var excludedVCenters map[string]bool
+			if tt.leaseVCenters > 0 {
+				// This matches the logic in pkg/controller/leases.go
+				vcentersInUse := make(map[string]bool)
+				for _, p := range tt.assignedPools {
+					if p.Spec.Server != "" {
+						vcentersInUse[p.Spec.Server] = true
+					}
+				}
+
+				if len(vcentersInUse) >= tt.leaseVCenters {
+					// Cap reached - build exclusion list
+					// (In real controller, this would check all available pools)
+					excludedVCenters = make(map[string]bool)
+					// For testing purposes, we'll check against the expected exclusions
+					if tt.expectedExcluded != nil {
+						for server := range tt.expectedExcluded {
+							if !vcentersInUse[server] {
+								excludedVCenters[server] = true
+							}
+						}
+					}
+				}
+			}
+
+			// Verify exclusions match expectations
+			if tt.expectExclusions {
+				if excludedVCenters == nil {
+					t.Error("Expected exclusions but got none")
+				} else if tt.expectedExcluded != nil {
+					for server := range tt.expectedExcluded {
+						if !excludedVCenters[server] {
+							t.Errorf("Expected server %q to be excluded but it was not", server)
+						}
+					}
+				}
+			} else {
+				if len(excludedVCenters) > 0 {
+					t.Errorf("Expected no exclusions but got %v", excludedVCenters)
+				}
+			}
+		})
+	}
+}
+
+// TestLeaseVCentersPoolsInteraction tests the semantic interaction between Pools and VCenters fields
+func TestLeaseVCentersPoolsInteraction(t *testing.T) {
+	tests := []struct {
+		name        string
+		pools       int
+		vcenters    int
+		description string
+		valid       bool
+	}{
+		{
+			name:        "vcenters equals pools - each pool different vcenter",
+			pools:       3,
+			vcenters:    3,
+			description: "Lease requests 3 pools across up to 3 vcenters",
+			valid:       true,
+		},
+		{
+			name:        "vcenters less than pools - requires sharing",
+			pools:       4,
+			vcenters:    2,
+			description: "Lease requests 4 pools but limited to 2 vcenters - pools must share vcenters",
+			valid:       true,
+		},
+		{
+			name:        "vcenters greater than pools - cap not binding",
+			pools:       2,
+			vcenters:    5,
+			description: "Lease allows up to 5 vcenters but only needs 2 pools - cap won't be reached",
+			valid:       true,
+		},
+		{
+			name:        "vcenters zero - no limit",
+			pools:       10,
+			vcenters:    0,
+			description: "No vcenter cap - pools can span any number of vcenters",
+			valid:       true,
+		},
+		{
+			name:        "single pool single vcenter",
+			pools:       1,
+			vcenters:    1,
+			description: "Simplest case - one pool on one vcenter",
+			valid:       true,
+		},
+		{
+			name:        "many pools single vcenter",
+			pools:       10,
+			vcenters:    1,
+			description: "All pools must be on the same vcenter",
+			valid:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lease := &v1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-lease",
+					Namespace: "default",
+				},
+				Spec: v1.LeaseSpec{
+					VCpus:    16,
+					Memory:   32,
+					Pools:    tt.pools,
+					VCenters: tt.vcenters,
+				},
+			}
+
+			// All of these should be valid lease configurations
+			if lease.Spec.Pools != tt.pools {
+				t.Errorf("Expected Pools=%d, got %d", tt.pools, lease.Spec.Pools)
+			}
+			if lease.Spec.VCenters != tt.vcenters {
+				t.Errorf("Expected VCenters=%d, got %d", tt.vcenters, lease.Spec.VCenters)
+			}
+
+			// Document the semantics
+			t.Logf("Semantic: %s", tt.description)
+			if tt.vcenters > 0 && tt.vcenters < tt.pools {
+				t.Logf("  → Pools must be distributed across at most %d vcenters", tt.vcenters)
+			} else if tt.vcenters == 0 {
+				t.Logf("  → No vcenter diversity constraint")
+			} else if tt.vcenters >= tt.pools {
+				t.Logf("  → Vcenter cap (%d) is not binding for %d pools", tt.vcenters, tt.pools)
 			}
 		})
 	}

--- a/pkg/utils/pools.go
+++ b/pkg/utils/pools.go
@@ -18,6 +18,7 @@ const (
 	PoolInsufficientMemory = "Insufficient memory"
 	PoolLabelMismatch      = "Pool labels do not match poolSelector"
 	PoolTaintNotTolerated  = "Pool has taints not tolerated by lease"
+	PoolVCenterLimitReached = "Pool vCenter limit reached"
 )
 
 type PoolFittingInfo struct {
@@ -92,10 +93,24 @@ func poolMatchesSelector(lease *v1.Lease, pool *v1.Pool) bool {
 	return true
 }
 
+// GetVCentersInUse returns the set of distinct vCenter Server FQDNs already used
+// by the given pools (e.g., a lease's currently-assigned pools).
+func GetVCentersInUse(assignedPools []*v1.Pool) map[string]bool {
+	vcenters := make(map[string]bool)
+	for _, pool := range assignedPools {
+		if pool.Spec.Server != "" {
+			vcenters[pool.Spec.Server] = true
+		}
+	}
+	return vcenters
+}
+
 // GetFittingPools returns a list of pools that have enough resources to satisfy the resource requirements and a list of
 // PoolFittingInfo specifying why pool is not a match.
 // The list is sorted by the sum of the resource usage of the pool. The pool with the least resource usage is first.
-func GetFittingPools(lease *v1.Lease, pools []*v1.Pool) ([]*v1.Pool, []*PoolFittingInfo) {
+// excludedVCenters is an optional set of vCenter Server FQDNs to exclude from consideration (used to enforce
+// the lease's VCenters cap). Pass nil or an empty map for no vcenter constraint.
+func GetFittingPools(lease *v1.Lease, pools []*v1.Pool, excludedVCenters map[string]bool) ([]*v1.Pool, []*PoolFittingInfo) {
 	var fittingPools []*v1.Pool
 	poolResults := []*PoolFittingInfo{}
 
@@ -110,6 +125,12 @@ func GetFittingPools(lease *v1.Lease, pools []*v1.Pool) ([]*v1.Pool, []*PoolFitt
 		}
 		if alreadyOwned {
 			poolResults = append(poolResults, &PoolFittingInfo{Pool: pool, MatchResults: "Pool already assigned to lease"})
+			continue
+		}
+
+		// If a vCenter cap is in effect, skip pools on excluded vCenters
+		if len(excludedVCenters) > 0 && excludedVCenters[pool.Spec.Server] {
+			poolResults = append(poolResults, &PoolFittingInfo{Pool: pool, MatchResults: PoolVCenterLimitReached})
 			continue
 		}
 
@@ -181,8 +202,10 @@ func generatePoolResults(results []*PoolFittingInfo) []string {
 }
 
 // GetPoolWithStrategy returns a pool that has enough resources to satisfy the lease requirements.
-func GetPoolWithStrategy(lease *v1.Lease, pools []*v1.Pool, strategy v1.AllocationStrategy) (*v1.Pool, error) {
-	fittingPools, results := GetFittingPools(lease, pools)
+// excludedVCenters is an optional set of vCenter Server FQDNs to exclude (enforces the VCenters cap).
+// Pass nil for no vcenter constraint.
+func GetPoolWithStrategy(lease *v1.Lease, pools []*v1.Pool, strategy v1.AllocationStrategy, excludedVCenters map[string]bool) (*v1.Pool, error) {
+	fittingPools, results := GetFittingPools(lease, pools, excludedVCenters)
 
 	if len(fittingPools) == 0 {
 		return nil, fmt.Errorf("no pools available. %v", generatePoolResults(results))

--- a/pkg/utils/pools.go
+++ b/pkg/utils/pools.go
@@ -11,13 +11,13 @@ import (
 )
 
 const (
-	PoolNotSchedulable     = "Pool not schedulable"
-	PoolExcluded           = "Pool marked as excluded"
-	PoolNotMatchRequired   = "Pool does not match required"
-	PoolInsufficientVCPU   = "Insufficient VCPU"
-	PoolInsufficientMemory = "Insufficient memory"
-	PoolLabelMismatch      = "Pool labels do not match poolSelector"
-	PoolTaintNotTolerated  = "Pool has taints not tolerated by lease"
+	PoolNotSchedulable      = "Pool not schedulable"
+	PoolExcluded            = "Pool marked as excluded"
+	PoolNotMatchRequired    = "Pool does not match required"
+	PoolInsufficientVCPU    = "Insufficient VCPU"
+	PoolInsufficientMemory  = "Insufficient memory"
+	PoolLabelMismatch       = "Pool labels do not match poolSelector"
+	PoolTaintNotTolerated   = "Pool has taints not tolerated by lease"
 	PoolVCenterLimitReached = "Pool vCenter limit reached"
 )
 
@@ -128,12 +128,6 @@ func GetFittingPools(lease *v1.Lease, pools []*v1.Pool, excludedVCenters map[str
 			continue
 		}
 
-		// If a vCenter cap is in effect, skip pools on excluded vCenters
-		if len(excludedVCenters) > 0 && excludedVCenters[pool.Spec.Server] {
-			poolResults = append(poolResults, &PoolFittingInfo{Pool: pool, MatchResults: PoolVCenterLimitReached})
-			continue
-		}
-
 		if pool.Spec.NoSchedule {
 			poolResults = append(poolResults, &PoolFittingInfo{Pool: pool, MatchResults: PoolNotSchedulable})
 			continue
@@ -155,6 +149,14 @@ func GetFittingPools(lease *v1.Lease, pools []*v1.Pool, excludedVCenters map[str
 		// Check if lease tolerates all pool taints
 		if !leaseToleratesPoolTaints(lease, pool) {
 			poolResults = append(poolResults, &PoolFittingInfo{Pool: pool, MatchResults: PoolTaintNotTolerated})
+			continue
+		}
+
+		// If a vCenter cap is in effect, skip pools on excluded vCenters
+		// This check comes after fundamental pool properties and lease requirements
+		// to ensure more specific rejection reasons are reported first
+		if len(excludedVCenters) > 0 && excludedVCenters[pool.Spec.Server] {
+			poolResults = append(poolResults, &PoolFittingInfo{Pool: pool, MatchResults: PoolVCenterLimitReached})
 			continue
 		}
 		if int(pool.Status.VCpusAvailable) >= lease.Spec.VCpus &&

--- a/pkg/utils/pools_test.go
+++ b/pkg/utils/pools_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"testing"
 
+	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/openshift-splat-team/vsphere-capacity-manager/pkg/apis/vspherecapacitymanager.splat.io/v1"
@@ -447,6 +448,7 @@ func TestGetFittingPools(t *testing.T) {
 		name               string
 		lease              *v1.Lease
 		pools              []*v1.Pool
+		excludedVCenters   map[string]bool
 		expectedFittingLen int
 		expectedRejections map[string]string
 	}{
@@ -677,11 +679,184 @@ func TestGetFittingPools(t *testing.T) {
 				"pool1": PoolInsufficientVCPU,
 			},
 		},
+		{
+			name: "excludedVCenters filters pools on capped vcenters",
+			lease: &v1.Lease{
+				Spec: v1.LeaseSpec{
+					VCpus:  16,
+					Memory: 32,
+				},
+			},
+			excludedVCenters: map[string]bool{
+				"vcenter1.example.com": true,
+				"vcenter2.example.com": true,
+			},
+			pools: []*v1.Pool{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-vc1",
+					},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus: 100,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  50,
+						MemoryAvailable: 100,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-vc2",
+					},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus: 100,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  50,
+						MemoryAvailable: 100,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-vc3",
+					},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter3.example.com",
+							},
+						},
+						VCpus: 100,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  50,
+						MemoryAvailable: 100,
+					},
+				},
+			},
+			// pool-vc3 is the only pool on a non-excluded vcenter
+			expectedFittingLen: 1,
+			expectedRejections: map[string]string{
+				"pool-vc1": PoolVCenterLimitReached,
+				"pool-vc2": PoolVCenterLimitReached,
+			},
+		},
+		{
+			name: "nil excludedVCenters applies no vcenter constraint",
+			lease: &v1.Lease{
+				Spec: v1.LeaseSpec{
+					VCpus:  16,
+					Memory: 32,
+				},
+			},
+			excludedVCenters: nil,
+			pools: []*v1.Pool{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-vc1",
+					},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus: 100,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  50,
+						MemoryAvailable: 100,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-vc2",
+					},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus: 100,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  50,
+						MemoryAvailable: 100,
+					},
+				},
+			},
+			// Both pools are fitting since no vcenter constraint is applied
+			expectedFittingLen: 2,
+			expectedRejections: map[string]string{},
+		},
+		{
+			name: "pool on non-excluded vcenter passes vcenter check",
+			lease: &v1.Lease{
+				Spec: v1.LeaseSpec{
+					VCpus:  16,
+					Memory: 32,
+				},
+			},
+			excludedVCenters: map[string]bool{
+				"vcenter1.example.com": true,
+			},
+			pools: []*v1.Pool{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-excluded",
+					},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus: 100,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  50,
+						MemoryAvailable: 100,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-allowed",
+					},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus: 100,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  50,
+						MemoryAvailable: 100,
+					},
+				},
+			},
+			expectedFittingLen: 1,
+			expectedRejections: map[string]string{
+				"pool-excluded": PoolVCenterLimitReached,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fittingPools, poolResults := GetFittingPools(tt.lease, tt.pools)
+			fittingPools, poolResults := GetFittingPools(tt.lease, tt.pools, tt.excludedVCenters)
 
 			if len(fittingPools) != tt.expectedFittingLen {
 				t.Errorf("GetFittingPools() returned %d fitting pools, expected %d",
@@ -702,6 +877,143 @@ func TestGetFittingPools(t *testing.T) {
 				}
 				if !found {
 					t.Errorf("Expected rejection for pool %s not found in results", poolName)
+				}
+			}
+		})
+	}
+}
+
+func TestGetVCentersInUse(t *testing.T) {
+	tests := []struct {
+		name          string
+		assignedPools []*v1.Pool
+		expected      map[string]bool
+	}{
+		{
+			name:          "empty assigned pools returns empty map",
+			assignedPools: []*v1.Pool{},
+			expected:      map[string]bool{},
+		},
+		{
+			name: "single pool returns its vcenter server",
+			assignedPools: []*v1.Pool{
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]bool{
+				"vcenter1.example.com": true,
+			},
+		},
+		{
+			name: "multiple pools on same vcenter deduplicates",
+			assignedPools: []*v1.Pool{
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+					},
+				},
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]bool{
+				"vcenter1.example.com": true,
+			},
+		},
+		{
+			name: "pools on different vcenters returns all servers",
+			assignedPools: []*v1.Pool{
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+					},
+				},
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+					},
+				},
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter3.example.com",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]bool{
+				"vcenter1.example.com": true,
+				"vcenter2.example.com": true,
+				"vcenter3.example.com": true,
+			},
+		},
+		{
+			name: "pool with empty server is skipped",
+			assignedPools: []*v1.Pool{
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "",
+							},
+						},
+					},
+				},
+				{
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]bool{
+				"vcenter1.example.com": true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetVCentersInUse(tt.assignedPools)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("GetVCentersInUse() returned %d vcenters, expected %d: got %v, want %v",
+					len(result), len(tt.expected), result, tt.expected)
+			}
+
+			for vcenter, expectedVal := range tt.expected {
+				if result[vcenter] != expectedVal {
+					t.Errorf("GetVCentersInUse() missing expected vcenter %q", vcenter)
 				}
 			}
 		})

--- a/pkg/utils/pools_test.go
+++ b/pkg/utils/pools_test.go
@@ -852,6 +852,80 @@ func TestGetFittingPools(t *testing.T) {
 				"pool-excluded": PoolVCenterLimitReached,
 			},
 		},
+		{
+			name: "vcenter check reports correct reason when pool has NoSchedule",
+			lease: &v1.Lease{
+				Spec: v1.LeaseSpec{
+					VCpus:  16,
+					Memory: 32,
+				},
+			},
+			excludedVCenters: map[string]bool{
+				"vcenter1.example.com": true,
+			},
+			pools: []*v1.Pool{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-noschedule",
+					},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:      100,
+						NoSchedule: true, // This should be reported instead of vcenter limit
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  50,
+						MemoryAvailable: 100,
+					},
+				},
+			},
+			expectedFittingLen: 0,
+			expectedRejections: map[string]string{
+				// Should report NoSchedule, not PoolVCenterLimitReached
+				"pool-noschedule": PoolNotSchedulable,
+			},
+		},
+		{
+			name: "vcenter check reports correct reason when pool is excluded",
+			lease: &v1.Lease{
+				Spec: v1.LeaseSpec{
+					VCpus:  16,
+					Memory: 32,
+				},
+			},
+			excludedVCenters: map[string]bool{
+				"vcenter1.example.com": true,
+			},
+			pools: []*v1.Pool{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pool-excluded",
+					},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:   100,
+						Exclude: true, // This should be reported instead of vcenter limit
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  50,
+						MemoryAvailable: 100,
+					},
+				},
+			},
+			expectedFittingLen: 0,
+			expectedRejections: map[string]string{
+				// Should report Exclude, not PoolVCenterLimitReached
+				"pool-excluded": PoolExcluded,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/leases_test.go
+++ b/test/leases_test.go
@@ -861,7 +861,7 @@ var _ = Describe("Lease management", func() {
 				_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(testLease2), testLease2)
 
 				return testLease1.Status.Phase == v1.PHASE_PARTIAL && testLease2.Status.Phase == v1.PHASE_PENDING
-			}).Should(BeTrue())
+			}, 15*time.Second, 500*time.Millisecond).Should(BeTrue())
 		})
 
 		// Now delete a lease so that the target lease will finally get enough to fill its requirements
@@ -882,7 +882,7 @@ var _ = Describe("Lease management", func() {
 				_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(testLease1), testLease1)
 				_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(testLease2), testLease2)
 				return testLease1.Status.Phase == v1.PHASE_FULFILLED && testLease2.Status.Phase != v1.PHASE_FULFILLED
-			}).Should(BeTrue())
+			}, 15*time.Second, 500*time.Millisecond).Should(BeTrue())
 		})
 
 		// Now wait for lease 2 to now be partial
@@ -910,8 +910,42 @@ var _ = Describe("Lease management", func() {
 			Eventually(func() bool {
 				_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(testLease1), testLease1)
 				_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(testLease2), testLease2)
-				return testLease1.Status.Phase == v1.PHASE_FULFILLED && testLease2.Status.Phase == v1.PHASE_FULFILLED
-			}).Should(BeTrue())
+
+				// Count pool owner references
+				poolCount1 := 0
+				networkCount1 := 0
+				for _, ref := range testLease1.OwnerReferences {
+					if ref.Kind == "Pool" {
+						poolCount1++
+					} else if ref.Kind == "Network" {
+						networkCount1++
+					}
+				}
+
+				poolCount2 := 0
+				networkCount2 := 0
+				for _, ref := range testLease2.OwnerReferences {
+					if ref.Kind == "Pool" {
+						poolCount2++
+					} else if ref.Kind == "Network" {
+						networkCount2++
+					}
+				}
+
+				log.Printf("[DEBUG] testLease1 (%s): phase=%s, pools=%d, networks=%d, VCenters=%d, requested_networks=%d",
+					testLease1.Name, testLease1.Status.Phase, poolCount1, networkCount1,
+					testLease1.Spec.VCenters, testLease1.Spec.Networks)
+				log.Printf("[DEBUG] testLease2 (%s): phase=%s, pools=%d, networks=%d, VCenters=%d, requested_networks=%d",
+					testLease2.Name, testLease2.Status.Phase, poolCount2, networkCount2,
+					testLease2.Spec.VCenters, testLease2.Spec.Networks)
+
+				fulfilled := testLease1.Status.Phase == v1.PHASE_FULFILLED && testLease2.Status.Phase == v1.PHASE_FULFILLED
+				if !fulfilled {
+					log.Printf("[DEBUG] Not yet fulfilled. testLease1=%s, testLease2=%s",
+						testLease1.Status.Phase, testLease2.Status.Phase)
+				}
+				return fulfilled
+			}, 45*time.Second, 500*time.Millisecond).Should(BeTrue())
 		})
 
 		// Cleanup all test


### PR DESCRIPTION
[SPLAT-2238](https://redhat.atlassian.net/browse/SPLAT-2238)

### Changes
- Added new vcenters field in lease to limit max number of vCenters

### Notes
For these changes, we did not hard code the limit of max vCenters to 3.  In OCP at the time of this PR, the maxed allowed vCenters in infrastructure spec is 3, but when we change this in the future, by leaving this open ended for max limit, we will not have to change VCM.  Instead, we plan on having CI, when requesting more than 3 FDs, to specify  max vcenter to 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added an optional `vcenters` Lease setting to cap the maximum number of distinct vCenters used when fulfilling a lease (`0` or unset means no limit).

* **Bug Fixes**
  * Improved additional pool assignment to respect the vCenter cap by excluding pools on vCenters already in use (while still honoring existing scheduling/exclusion rules).

* **Tests**
  * Added/extended tests for vCenter filtering and “vCenters in use” calculation, and tightened lease fulfillment polling/verification logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->