### PR TITLE
SPLAT-2238: Fixed vCenter selection logic for single vCenter multiple pools

### DIFF
--- a/pkg/controller/leases.go
+++ b/pkg/controller/leases.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math/rand/v2"
 	"path"
+	"sort"
 	"strconv"
 	"time"
 
@@ -787,13 +788,16 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			} else if lease.Spec.VCenters < requiredPools && len(assignedPools) == 0 {
 				// Special case: if we need more pools than vCenters allowed (VCenters < Pools),
 				// and we haven't assigned any pools yet, we must ensure we only pick from
-				// vCenters that have enough pools to potentially fulfill the lease.
-				// Use a greedy heuristic: require each vCenter to have at least ceil(Pools/VCenters) pools.
+				// vCenters that can participate in a valid combination to fulfill the lease.
+				//
+				// Use greedy selection: sort vCenters by pool count descending, check if
+				// the top VCenters vCenters have enough pools total. Only exclude vCenters
+				// that cannot participate in any valid combination.
 
 				// Reuse GetFittingPools to apply consistent filtering logic
 				fittingPools, _ := utils.GetFittingPools(lease, availablePools, nil)
 
-				// Group fitting pools by vCenter
+				// Group fitting pools by vCenter and count them
 				fittingPoolsPerVCenter := make(map[string][]*v1.Pool)
 				for _, p := range fittingPools {
 					if p.Spec.Server != "" {
@@ -801,23 +805,75 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 					}
 				}
 
-				// Calculate minimum pools per vCenter using ceiling division
-				// For VCenters=2, Pools=3: minPoolsPerVCenter = ceil(3/2) = 2
-				// For VCenters=1, Pools=3: minPoolsPerVCenter = ceil(3/1) = 3
-				minPoolsPerVCenter := (requiredPools + lease.Spec.VCenters - 1) / lease.Spec.VCenters
+				// Build sorted list of vCenters by pool count (descending)
+				type vcenterPoolCount struct {
+					server string
+					count  int
+				}
+				vcenterCounts := make([]vcenterPoolCount, 0, len(fittingPoolsPerVCenter))
+				for server, pools := range fittingPoolsPerVCenter {
+					vcenterCounts = append(vcenterCounts, vcenterPoolCount{server: server, count: len(pools)})
+				}
+				sort.Slice(vcenterCounts, func(i, j int) bool {
+					return vcenterCounts[i].count > vcenterCounts[j].count
+				})
 
-				// Exclude vCenters that don't have enough suitable pools
-				excludedVCenters = make(map[string]bool)
-				for _, p := range availablePools {
-					if p.Spec.Server != "" && len(fittingPoolsPerVCenter[p.Spec.Server]) < minPoolsPerVCenter {
-						excludedVCenters[p.Spec.Server] = true
-					}
+				// Calculate total pools available from top VCenters vCenters
+				topVCentersPoolCount := 0
+				numVCentersToUse := lease.Spec.VCenters
+				if numVCentersToUse > len(vcenterCounts) {
+					numVCentersToUse = len(vcenterCounts)
+				}
+				for i := 0; i < numVCentersToUse; i++ {
+					topVCentersPoolCount += vcenterCounts[i].count
 				}
 
-				// Log exclusions without exposing full vCenter FQDNs (count only)
-				if len(excludedVCenters) > 0 {
-					log.Printf("Lease %s: excluded %d vCenters with insufficient pools (need min %d pools per vCenter for %d total pools across %d vCenters)",
-						lease.Name, len(excludedVCenters), minPoolsPerVCenter, requiredPools, lease.Spec.VCenters)
+				// If the top VCenters vCenters don't have enough pools total, we can't fulfill
+				// In this case, keep all vCenters (no exclusions) and let the normal flow handle it
+				if topVCentersPoolCount < requiredPools {
+					log.Printf("Lease %s: top %d vCenters only have %d pools total, need %d - no exclusions applied",
+						lease.Name, numVCentersToUse, topVCentersPoolCount, requiredPools)
+				} else {
+					// We can potentially fulfill. Exclude vCenters that can't participate in any valid combination.
+					// A vCenter can participate if: when combined with the top (VCenters-1) OTHER vCenters,
+					// the total is >= requiredPools.
+					excludedVCenters = make(map[string]bool)
+
+					for _, vc := range vcenterCounts {
+						// For each vCenter, check if it can participate by combining with the best others
+						// We need to check: this vCenter + top (VCenters-1) others >= requiredPools
+						canParticipate := false
+
+						// Simple check: if this vCenter + total from top (VCenters-1) other vCenters >= requiredPools
+						othersPoolCount := 0
+						othersConsidered := 0
+						for _, other := range vcenterCounts {
+							if other.server != vc.server && othersConsidered < lease.Spec.VCenters-1 {
+								othersPoolCount += other.count
+								othersConsidered++
+							}
+						}
+
+						if vc.count+othersPoolCount >= requiredPools {
+							canParticipate = true
+						}
+
+						// Exclude vCenters that cannot participate in any valid combination
+						if !canParticipate {
+							for _, p := range availablePools {
+								if p.Spec.Server == vc.server {
+									excludedVCenters[vc.server] = true
+									break
+								}
+							}
+						}
+					}
+
+					// Log exclusions without exposing full vCenter FQDNs (count only)
+					if len(excludedVCenters) > 0 {
+						log.Printf("Lease %s: excluded %d vCenters that cannot participate in valid combinations (need %d pools from %d vCenters, top %d have %d total)",
+							lease.Name, len(excludedVCenters), requiredPools, lease.Spec.VCenters, numVCentersToUse, topVCentersPoolCount)
+					}
 				}
 			}
 		}

--- a/pkg/controller/leases.go
+++ b/pkg/controller/leases.go
@@ -784,14 +784,73 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 						excludedVCenters[srv] = true
 					}
 				}
+			} else if lease.Spec.VCenters < requiredPools && len(assignedPools) == 0 {
+				// Special case: if we need more pools than vCenters allowed (VCenters < Pools),
+				// and we haven't assigned any pools yet, we must ensure we only pick from
+				// vCenters that have enough pools to potentially fulfill the lease.
+				// Use a greedy heuristic: require each vCenter to have at least ceil(Pools/VCenters) pools.
+				// Get fitting pools per vCenter by doing a preliminary filter
+				fittingPoolsPerVCenter := make(map[string][]*v1.Pool)
+				for _, p := range availablePools {
+					if p.Spec.Server == "" {
+						continue
+					}
+					// Do basic filtering to see if this pool could be assigned
+					if p.Spec.NoSchedule {
+						continue
+					}
+					if p.Spec.Exclude && lease.Spec.RequiredPool != p.ObjectMeta.Name {
+						continue
+					}
+					if len(lease.Spec.RequiredPool) > 0 && lease.Spec.RequiredPool != p.ObjectMeta.Name {
+						continue
+					}
+					if !utils.PoolMatchesSelector(lease, p) {
+						continue
+					}
+					if !utils.LeaseToleratesPoolTaints(lease, p) {
+						continue
+					}
+					if int(p.Status.VCpusAvailable) < lease.Spec.VCpus || int(p.Status.MemoryAvailable) < lease.Spec.Memory {
+						continue
+					}
+					fittingPoolsPerVCenter[p.Spec.Server] = append(fittingPoolsPerVCenter[p.Spec.Server], p)
+				}
+
+				// Calculate minimum pools per vCenter using ceiling division
+				// For VCenters=2, Pools=3: minPoolsPerVCenter = ceil(3/2) = 2
+				// For VCenters=1, Pools=3: minPoolsPerVCenter = ceil(3/1) = 3
+				minPoolsPerVCenter := (requiredPools + lease.Spec.VCenters - 1) / lease.Spec.VCenters
+
+				// Exclude vCenters that don't have enough suitable pools
+				excludedVCenters = make(map[string]bool)
+				for vcenter, pools := range fittingPoolsPerVCenter {
+					if len(pools) < minPoolsPerVCenter {
+						excludedVCenters[vcenter] = true
+						log.Printf("Excluding vcenter %s: only has %d suitable pools but lease %s needs at least %d pools per vCenter (total %d pools across %d vCenters)",
+							vcenter, len(pools), lease.Name, minPoolsPerVCenter, requiredPools, lease.Spec.VCenters)
+					}
+				}
+				// Also exclude vCenters not in the map (they have 0 suitable pools)
+				seenVCenters := make(map[string]bool)
+				for vcenter := range fittingPoolsPerVCenter {
+					seenVCenters[vcenter] = true
+				}
+				for _, p := range availablePools {
+					if p.Spec.Server != "" && !seenVCenters[p.Spec.Server] {
+						excludedVCenters[p.Spec.Server] = true
+					}
+				}
 			}
 		}
 
 		log.Printf("Attempting to assign pool %d/%d for lease %s, %d pools available after filtering", len(assignedPools)+1, requiredPools, lease.Name, len(availablePools))
 		log.Printf("Lease %s currently has %d owner references before GetPoolWithStrategy", lease.Name, len(lease.OwnerReferences))
+		log.Printf("Lease %s excludedVCenters: %v", lease.Name, excludedVCenters)
 
 		pool, err := utils.GetPoolWithStrategy(lease, availablePools, v1.RESOURCE_ALLOCATION_STRATEGY_UNDERUTILIZED, excludedVCenters)
 		if err != nil {
+			log.Printf("GetPoolWithStrategy error for lease %s: %v", lease.Name, err)
 			// If we already have some pools assigned, mark as partial
 			if len(assignedPools) > 0 {
 				log.Printf("lease %s needs %d pools but only %d available", lease.Name, requiredPools, len(assignedPools))

--- a/pkg/controller/leases.go
+++ b/pkg/controller/leases.go
@@ -789,32 +789,16 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 				// and we haven't assigned any pools yet, we must ensure we only pick from
 				// vCenters that have enough pools to potentially fulfill the lease.
 				// Use a greedy heuristic: require each vCenter to have at least ceil(Pools/VCenters) pools.
-				// Get fitting pools per vCenter by doing a preliminary filter
+
+				// Reuse GetFittingPools to apply consistent filtering logic
+				fittingPools, _ := utils.GetFittingPools(lease, availablePools, nil)
+
+				// Group fitting pools by vCenter
 				fittingPoolsPerVCenter := make(map[string][]*v1.Pool)
-				for _, p := range availablePools {
-					if p.Spec.Server == "" {
-						continue
+				for _, p := range fittingPools {
+					if p.Spec.Server != "" {
+						fittingPoolsPerVCenter[p.Spec.Server] = append(fittingPoolsPerVCenter[p.Spec.Server], p)
 					}
-					// Do basic filtering to see if this pool could be assigned
-					if p.Spec.NoSchedule {
-						continue
-					}
-					if p.Spec.Exclude && lease.Spec.RequiredPool != p.ObjectMeta.Name {
-						continue
-					}
-					if len(lease.Spec.RequiredPool) > 0 && lease.Spec.RequiredPool != p.ObjectMeta.Name {
-						continue
-					}
-					if !utils.PoolMatchesSelector(lease, p) {
-						continue
-					}
-					if !utils.LeaseToleratesPoolTaints(lease, p) {
-						continue
-					}
-					if int(p.Status.VCpusAvailable) < lease.Spec.VCpus || int(p.Status.MemoryAvailable) < lease.Spec.Memory {
-						continue
-					}
-					fittingPoolsPerVCenter[p.Spec.Server] = append(fittingPoolsPerVCenter[p.Spec.Server], p)
 				}
 
 				// Calculate minimum pools per vCenter using ceiling division
@@ -824,29 +808,25 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 				// Exclude vCenters that don't have enough suitable pools
 				excludedVCenters = make(map[string]bool)
-				for vcenter, pools := range fittingPoolsPerVCenter {
-					if len(pools) < minPoolsPerVCenter {
-						excludedVCenters[vcenter] = true
-						log.Printf("Excluding vcenter %s: only has %d suitable pools but lease %s needs at least %d pools per vCenter (total %d pools across %d vCenters)",
-							vcenter, len(pools), lease.Name, minPoolsPerVCenter, requiredPools, lease.Spec.VCenters)
-					}
-				}
-				// Also exclude vCenters not in the map (they have 0 suitable pools)
-				seenVCenters := make(map[string]bool)
-				for vcenter := range fittingPoolsPerVCenter {
-					seenVCenters[vcenter] = true
-				}
 				for _, p := range availablePools {
-					if p.Spec.Server != "" && !seenVCenters[p.Spec.Server] {
+					if p.Spec.Server != "" && len(fittingPoolsPerVCenter[p.Spec.Server]) < minPoolsPerVCenter {
 						excludedVCenters[p.Spec.Server] = true
 					}
+				}
+
+				// Log exclusions without exposing full vCenter FQDNs (count only)
+				if len(excludedVCenters) > 0 {
+					log.Printf("Lease %s: excluded %d vCenters with insufficient pools (need min %d pools per vCenter for %d total pools across %d vCenters)",
+						lease.Name, len(excludedVCenters), minPoolsPerVCenter, requiredPools, lease.Spec.VCenters)
 				}
 			}
 		}
 
 		log.Printf("Attempting to assign pool %d/%d for lease %s, %d pools available after filtering", len(assignedPools)+1, requiredPools, lease.Name, len(availablePools))
 		log.Printf("Lease %s currently has %d owner references before GetPoolWithStrategy", lease.Name, len(lease.OwnerReferences))
-		log.Printf("Lease %s excludedVCenters: %v", lease.Name, excludedVCenters)
+		if len(excludedVCenters) > 0 {
+			log.Printf("Lease %s: %d vCenters excluded from pool selection", lease.Name, len(excludedVCenters))
+		}
 
 		pool, err := utils.GetPoolWithStrategy(lease, availablePools, v1.RESOURCE_ALLOCATION_STRATEGY_UNDERUTILIZED, excludedVCenters)
 		if err != nil {

--- a/pkg/controller/leases_test.go
+++ b/pkg/controller/leases_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"sort"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -1180,35 +1181,11 @@ func TestLeaseVCenterPoolAvailability(t *testing.T) {
 			expectExclusions: false,
 		},
 		{
-			name:          "no exclusions when only 1 pool required",
-			requiredPools: 1,
-			vcentersLimit: 1,
-			availablePools: []*v1.Pool{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool1"},
-					Spec: v1.PoolSpec{
-						FailureDomainSpec: v1.FailureDomainSpec{
-							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
-								Server: "vcenter1.example.com",
-							},
-						},
-						VCpus:  100,
-						Memory: 1000,
-					},
-					Status: v1.PoolStatus{
-						VCpusAvailable:  100,
-						MemoryAvailable: 1000,
-					},
-				},
-			},
-			expectExclusions: false,
-		},
-		{
-			name:          "vcenters=2 pools=3 excludes vcenters with <2 pools",
+			name:          "maintenance scenario: vcenter with 1 pool combines with vcenter with 2 pools",
 			requiredPools: 3,
 			vcentersLimit: 2,
 			availablePools: []*v1.Pool{
-				// vcenter1 has only 1 pool - should be excluded (needs ceil(3/2)=2)
+				// vcenter1 had pools removed for maintenance, only 1 left
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool1"},
 					Spec: v1.PoolSpec{
@@ -1225,7 +1202,7 @@ func TestLeaseVCenterPoolAvailability(t *testing.T) {
 						MemoryAvailable: 1000,
 					},
 				},
-				// vcenter2 has 2 pools - sufficient
+				// vcenter2 has 2 pools available
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool1"},
 					Spec: v1.PoolSpec{
@@ -1258,7 +1235,89 @@ func TestLeaseVCenterPoolAvailability(t *testing.T) {
 						MemoryAvailable: 1000,
 					},
 				},
-				// vcenter3 has 2 pools - sufficient
+			},
+			expectExclusions: false, // Should NOT exclude vcenter1 - can combine 1+2=3
+		},
+		{
+			name:          "no exclusions when only 1 pool required",
+			requiredPools: 1,
+			vcentersLimit: 1,
+			availablePools: []*v1.Pool{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+			},
+			expectExclusions: false,
+		},
+		{
+			name:          "vcenters=2 pools=3 allows vcenter with 1 pool if can combine",
+			requiredPools: 3,
+			vcentersLimit: 2,
+			availablePools: []*v1.Pool{
+				// vcenter1 has 1 pool - can combine with vcenter2 (2 pools) = 3 total
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				// vcenter2 has 2 pools - can combine with vcenter1 (1 pool) = 3 total
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool2"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				// vcenter3 has 2 pools - can also combine
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "vcenter3-pool1"},
 					Spec: v1.PoolSpec{
@@ -1292,17 +1351,14 @@ func TestLeaseVCenterPoolAvailability(t *testing.T) {
 					},
 				},
 			},
-			expectExclusions: true,
-			expectedExcluded: map[string]bool{
-				"vcenter1.example.com": true, // only 1 pool, needs at least 2
-			},
+			expectExclusions: false, // No exclusions - all vCenters can participate
 		},
 		{
-			name:          "vcenters=2 pools=5 excludes vcenters with <3 pools",
+			name:          "vcenters=2 pools=5 allows vcenter with 2 pools if can combine with 3",
 			requiredPools: 5,
 			vcentersLimit: 2,
 			availablePools: []*v1.Pool{
-				// vcenter1 has 2 pools - insufficient (needs ceil(5/2)=3)
+				// vcenter1 has 2 pools - can combine with vcenter2 (3 pools) = 5 total
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool1"},
 					Spec: v1.PoolSpec{
@@ -1335,7 +1391,7 @@ func TestLeaseVCenterPoolAvailability(t *testing.T) {
 						MemoryAvailable: 1000,
 					},
 				},
-				// vcenter2 has 3 pools - sufficient
+				// vcenter2 has 3 pools - can combine with vcenter1 (2 pools) = 5 total
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool1"},
 					Spec: v1.PoolSpec{
@@ -1385,10 +1441,7 @@ func TestLeaseVCenterPoolAvailability(t *testing.T) {
 					},
 				},
 			},
-			expectExclusions: true,
-			expectedExcluded: map[string]bool{
-				"vcenter1.example.com": true, // only 2 pools, needs at least 3
-			},
+			expectExclusions: false, // No exclusions - vcenter1+vcenter2 = 5 pools
 		},
 	}
 
@@ -1424,6 +1477,7 @@ func TestLeaseVCenterPoolAvailability(t *testing.T) {
 					t.Skip("Test case is for pre-assignment filtering")
 				} else if lease.Spec.VCenters > 0 && lease.Spec.VCenters < tt.requiredPools && len(assignedPools) == 0 {
 					// This is the special case we're testing: VCenters < Pools
+					// Use the same algorithm as production code
 					fittingPoolsPerVCenter := make(map[string][]*v1.Pool)
 					for _, p := range tt.availablePools {
 						if p.Spec.Server == "" {
@@ -1444,26 +1498,49 @@ func TestLeaseVCenterPoolAvailability(t *testing.T) {
 						fittingPoolsPerVCenter[p.Spec.Server] = append(fittingPoolsPerVCenter[p.Spec.Server], p)
 					}
 
-					// Calculate minimum pools per vCenter using ceiling division
-					minPoolsPerVCenter := (tt.requiredPools + tt.vcentersLimit - 1) / tt.vcentersLimit
+					// Build sorted list of vCenters by pool count (descending)
+					type vcenterPoolCount struct {
+						server string
+						count  int
+					}
+					vcenterCounts := make([]vcenterPoolCount, 0, len(fittingPoolsPerVCenter))
+					for server, pools := range fittingPoolsPerVCenter {
+						vcenterCounts = append(vcenterCounts, vcenterPoolCount{server: server, count: len(pools)})
+					}
+					sort.Slice(vcenterCounts, func(i, j int) bool {
+						return vcenterCounts[i].count > vcenterCounts[j].count
+					})
 
-					excludedVCenters = make(map[string]bool)
-					for vcenter, pools := range fittingPoolsPerVCenter {
-						if len(pools) < minPoolsPerVCenter {
-							excludedVCenters[vcenter] = true
-							t.Logf("Excluding vcenter %s: only has %d suitable pools but needs at least %d per vCenter (total %d pools across %d vCenters)",
-								vcenter, len(pools), minPoolsPerVCenter, tt.requiredPools, tt.vcentersLimit)
-						}
+					// Calculate total pools from top VCenters vCenters
+					topVCentersPoolCount := 0
+					numVCentersToUse := tt.vcentersLimit
+					if numVCentersToUse > len(vcenterCounts) {
+						numVCentersToUse = len(vcenterCounts)
+					}
+					for i := 0; i < numVCentersToUse; i++ {
+						topVCentersPoolCount += vcenterCounts[i].count
 					}
 
-					// Also exclude vCenters not in the map (0 suitable pools)
-					seenVCenters := make(map[string]bool)
-					for vcenter := range fittingPoolsPerVCenter {
-						seenVCenters[vcenter] = true
-					}
-					for _, p := range tt.availablePools {
-						if p.Spec.Server != "" && !seenVCenters[p.Spec.Server] {
-							excludedVCenters[p.Spec.Server] = true
+					// Only apply exclusions if we can potentially fulfill
+					if topVCentersPoolCount >= tt.requiredPools {
+						excludedVCenters = make(map[string]bool)
+
+						for _, vc := range vcenterCounts {
+							// Check if this vCenter can participate
+							othersPoolCount := 0
+							othersConsidered := 0
+							for _, other := range vcenterCounts {
+								if other.server != vc.server && othersConsidered < tt.vcentersLimit-1 {
+									othersPoolCount += other.count
+									othersConsidered++
+								}
+							}
+
+							if vc.count+othersPoolCount < tt.requiredPools {
+								excludedVCenters[vc.server] = true
+								t.Logf("Excluding vcenter %s: %d pools + %d from others = %d < %d required",
+									vc.server, vc.count, othersPoolCount, vc.count+othersPoolCount, tt.requiredPools)
+							}
 						}
 					}
 				}

--- a/pkg/controller/leases_test.go
+++ b/pkg/controller/leases_test.go
@@ -896,6 +896,605 @@ func TestLeaseVCentersCapEnforcement(t *testing.T) {
 	}
 }
 
+// TestLeaseVCenterPoolAvailability tests that when VCenters=1 and Pools>1,
+// we only select from vCenters that have enough suitable pools
+func TestLeaseVCenterPoolAvailability(t *testing.T) {
+	tests := []struct {
+		name             string
+		requiredPools    int
+		vcentersLimit    int
+		availablePools   []*v1.Pool
+		expectExclusions bool
+		expectedExcluded map[string]bool
+	}{
+		{
+			name:          "vcenter with insufficient pools is excluded",
+			requiredPools: 3,
+			vcentersLimit: 1,
+			availablePools: []*v1.Pool{
+				// vcenter1 has only 1 pool - insufficient for 3 pools
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				// vcenter2 has 3 pools - sufficient for 3 pools
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool2"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool3"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+			},
+			expectExclusions: true,
+			expectedExcluded: map[string]bool{
+				"vcenter1.example.com": true, // only 1 pool, needs 3
+			},
+		},
+		{
+			name:          "vcenter with insufficient resources is excluded",
+			requiredPools: 2,
+			vcentersLimit: 1,
+			availablePools: []*v1.Pool{
+				// vcenter1 has 2 pools, but one lacks resources
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool2"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  5,  // insufficient
+						MemoryAvailable: 10, // insufficient
+					},
+				},
+				// vcenter2 has 2 pools with sufficient resources
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool2"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+			},
+			expectExclusions: true,
+			expectedExcluded: map[string]bool{
+				"vcenter1.example.com": true, // only 1 suitable pool, needs 2
+			},
+		},
+		{
+			name:          "vcenter with excluded pools counted correctly",
+			requiredPools: 2,
+			vcentersLimit: 1,
+			availablePools: []*v1.Pool{
+				// vcenter1 has 2 pools, but one is marked exclude
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool2"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:   100,
+						Memory:  1000,
+						Exclude: true, // This pool should not be counted
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				// vcenter2 has 2 schedulable pools
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool2"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+			},
+			expectExclusions: true,
+			expectedExcluded: map[string]bool{
+				"vcenter1.example.com": true, // only 1 suitable pool (pool2 is excluded), needs 2
+			},
+		},
+		{
+			name:          "no exclusions when VCenters >= Pools",
+			requiredPools: 2,
+			vcentersLimit: 3, // Can use 3 vCenters for 2 pools, no pre-filtering needed
+			availablePools: []*v1.Pool{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+			},
+			expectExclusions: false,
+		},
+		{
+			name:          "no exclusions when only 1 pool required",
+			requiredPools: 1,
+			vcentersLimit: 1,
+			availablePools: []*v1.Pool{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+			},
+			expectExclusions: false,
+		},
+		{
+			name:          "vcenters=2 pools=3 excludes vcenters with <2 pools",
+			requiredPools: 3,
+			vcentersLimit: 2,
+			availablePools: []*v1.Pool{
+				// vcenter1 has only 1 pool - should be excluded (needs ceil(3/2)=2)
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				// vcenter2 has 2 pools - sufficient
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool2"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				// vcenter3 has 2 pools - sufficient
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter3-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter3.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter3-pool2"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter3.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+			},
+			expectExclusions: true,
+			expectedExcluded: map[string]bool{
+				"vcenter1.example.com": true, // only 1 pool, needs at least 2
+			},
+		},
+		{
+			name:          "vcenters=2 pools=5 excludes vcenters with <3 pools",
+			requiredPools: 5,
+			vcentersLimit: 2,
+			availablePools: []*v1.Pool{
+				// vcenter1 has 2 pools - insufficient (needs ceil(5/2)=3)
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool2"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				// vcenter2 has 3 pools - sufficient
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool2"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool3"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+			},
+			expectExclusions: true,
+			expectedExcluded: map[string]bool{
+				"vcenter1.example.com": true, // only 2 pools, needs at least 3
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lease := &v1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-lease",
+					Namespace: "default",
+				},
+				Spec: v1.LeaseSpec{
+					VCpus:    16,
+					Memory:   32,
+					Pools:    tt.requiredPools,
+					VCenters: tt.vcentersLimit,
+				},
+			}
+
+			// Simulate the controller logic for pre-filtering vCenters
+			var excludedVCenters map[string]bool
+			assignedPools := []*v1.Pool{} // No pools assigned yet
+
+			if lease.Spec.VCenters > 0 {
+				vcentersInUse := make(map[string]bool)
+				for _, p := range assignedPools {
+					if p.Spec.Server != "" {
+						vcentersInUse[p.Spec.Server] = true
+					}
+				}
+
+				if len(vcentersInUse) >= lease.Spec.VCenters {
+					// Cap already reached - not testing this case
+					t.Skip("Test case is for pre-assignment filtering")
+				} else if lease.Spec.VCenters > 0 && lease.Spec.VCenters < tt.requiredPools && len(assignedPools) == 0 {
+					// This is the special case we're testing: VCenters < Pools
+					fittingPoolsPerVCenter := make(map[string][]*v1.Pool)
+					for _, p := range tt.availablePools {
+						if p.Spec.Server == "" {
+							continue
+						}
+						if p.Spec.NoSchedule {
+							continue
+						}
+						if p.Spec.Exclude && lease.Spec.RequiredPool != p.ObjectMeta.Name {
+							continue
+						}
+						if len(lease.Spec.RequiredPool) > 0 && lease.Spec.RequiredPool != p.ObjectMeta.Name {
+							continue
+						}
+						if int(p.Status.VCpusAvailable) < lease.Spec.VCpus || int(p.Status.MemoryAvailable) < lease.Spec.Memory {
+							continue
+						}
+						fittingPoolsPerVCenter[p.Spec.Server] = append(fittingPoolsPerVCenter[p.Spec.Server], p)
+					}
+
+					// Calculate minimum pools per vCenter using ceiling division
+					minPoolsPerVCenter := (tt.requiredPools + tt.vcentersLimit - 1) / tt.vcentersLimit
+
+					excludedVCenters = make(map[string]bool)
+					for vcenter, pools := range fittingPoolsPerVCenter {
+						if len(pools) < minPoolsPerVCenter {
+							excludedVCenters[vcenter] = true
+							t.Logf("Excluding vcenter %s: only has %d suitable pools but needs at least %d per vCenter (total %d pools across %d vCenters)",
+								vcenter, len(pools), minPoolsPerVCenter, tt.requiredPools, tt.vcentersLimit)
+						}
+					}
+
+					// Also exclude vCenters not in the map (0 suitable pools)
+					seenVCenters := make(map[string]bool)
+					for vcenter := range fittingPoolsPerVCenter {
+						seenVCenters[vcenter] = true
+					}
+					for _, p := range tt.availablePools {
+						if p.Spec.Server != "" && !seenVCenters[p.Spec.Server] {
+							excludedVCenters[p.Spec.Server] = true
+						}
+					}
+				}
+			}
+
+			// Verify exclusions match expectations
+			if tt.expectExclusions {
+				if len(excludedVCenters) == 0 {
+					t.Error("Expected exclusions but got none")
+				} else if tt.expectedExcluded != nil {
+					for server := range tt.expectedExcluded {
+						if !excludedVCenters[server] {
+							t.Errorf("Expected server %q to be excluded but it was not", server)
+						}
+					}
+					// Verify we didn't exclude anything extra
+					for server := range excludedVCenters {
+						if !tt.expectedExcluded[server] {
+							t.Errorf("Server %q was excluded but should not have been", server)
+						}
+					}
+				}
+			} else {
+				if len(excludedVCenters) > 0 {
+					t.Errorf("Expected no exclusions but got %v", excludedVCenters)
+				}
+			}
+		})
+	}
+}
+
 // TestLeaseVCentersPoolsInteraction tests the semantic interaction between Pools and VCenters fields
 func TestLeaseVCentersPoolsInteraction(t *testing.T) {
 	tests := []struct {

--- a/pkg/utils/pools.go
+++ b/pkg/utils/pools.go
@@ -11,14 +11,15 @@ import (
 )
 
 const (
-	PoolNotSchedulable      = "Pool not schedulable"
-	PoolExcluded            = "Pool marked as excluded"
-	PoolNotMatchRequired    = "Pool does not match required"
-	PoolInsufficientVCPU    = "Insufficient VCPU"
-	PoolInsufficientMemory  = "Insufficient memory"
-	PoolLabelMismatch       = "Pool labels do not match poolSelector"
-	PoolTaintNotTolerated   = "Pool has taints not tolerated by lease"
-	PoolVCenterLimitReached = "Pool vCenter limit reached"
+	PoolNotSchedulable           = "Pool not schedulable"
+	PoolExcluded                 = "Pool marked as excluded"
+	PoolNotMatchRequired         = "Pool does not match required"
+	PoolInsufficientVCPU         = "Insufficient VCPU"
+	PoolInsufficientMemory       = "Insufficient memory"
+	PoolLabelMismatch            = "Pool labels do not match poolSelector"
+	PoolTaintNotTolerated        = "Pool has taints not tolerated by lease"
+	PoolVCenterLimitReached      = "Pool vCenter limit reached"
+	PoolVCenterInsufficientPools = "vCenter does not have enough pools for lease"
 )
 
 type PoolFittingInfo struct {
@@ -44,9 +45,9 @@ func tolerationMatchesTaint(toleration *v1.Toleration, taint *v1.Taint) bool {
 	return toleration.Key == taint.Key && toleration.Value == taint.Value
 }
 
-// leaseToleratesPoolTaints checks if a lease has tolerations for all of a pool's taints.
+// LeaseToleratesPoolTaints checks if a lease has tolerations for all of a pool's taints.
 // Returns true if the lease can be scheduled on the pool, false otherwise.
-func leaseToleratesPoolTaints(lease *v1.Lease, pool *v1.Pool) bool {
+func LeaseToleratesPoolTaints(lease *v1.Lease, pool *v1.Pool) bool {
 	// If pool has no taints, lease can always be scheduled
 	if len(pool.Spec.Taints) == 0 {
 		return true
@@ -74,9 +75,9 @@ func leaseToleratesPoolTaints(lease *v1.Lease, pool *v1.Pool) bool {
 	return true
 }
 
-// poolMatchesSelector checks if a pool's labels match the lease's poolSelector.
+// PoolMatchesSelector checks if a pool's labels match the lease's poolSelector.
 // Returns true if all selector labels match the pool's labels.
-func poolMatchesSelector(lease *v1.Lease, pool *v1.Pool) bool {
+func PoolMatchesSelector(lease *v1.Lease, pool *v1.Pool) bool {
 	// If no selector is specified, pool matches
 	if len(lease.Spec.PoolSelector) == 0 {
 		return true
@@ -142,12 +143,12 @@ func GetFittingPools(lease *v1.Lease, pools []*v1.Pool, excludedVCenters map[str
 			continue
 		}
 		// Check if pool labels match the lease's poolSelector
-		if !poolMatchesSelector(lease, pool) {
+		if !PoolMatchesSelector(lease, pool) {
 			poolResults = append(poolResults, &PoolFittingInfo{Pool: pool, MatchResults: PoolLabelMismatch})
 			continue
 		}
 		// Check if lease tolerates all pool taints
-		if !leaseToleratesPoolTaints(lease, pool) {
+		if !LeaseToleratesPoolTaints(lease, pool) {
 			poolResults = append(poolResults, &PoolFittingInfo{Pool: pool, MatchResults: PoolTaintNotTolerated})
 			continue
 		}

--- a/pkg/utils/pools.go
+++ b/pkg/utils/pools.go
@@ -11,15 +11,14 @@ import (
 )
 
 const (
-	PoolNotSchedulable           = "Pool not schedulable"
-	PoolExcluded                 = "Pool marked as excluded"
-	PoolNotMatchRequired         = "Pool does not match required"
-	PoolInsufficientVCPU         = "Insufficient VCPU"
-	PoolInsufficientMemory       = "Insufficient memory"
-	PoolLabelMismatch            = "Pool labels do not match poolSelector"
-	PoolTaintNotTolerated        = "Pool has taints not tolerated by lease"
-	PoolVCenterLimitReached      = "Pool vCenter limit reached"
-	PoolVCenterInsufficientPools = "vCenter does not have enough pools for lease"
+	PoolNotSchedulable      = "Pool not schedulable"
+	PoolExcluded            = "Pool marked as excluded"
+	PoolNotMatchRequired    = "Pool does not match required"
+	PoolInsufficientVCPU    = "Insufficient VCPU"
+	PoolInsufficientMemory  = "Insufficient memory"
+	PoolLabelMismatch       = "Pool labels do not match poolSelector"
+	PoolTaintNotTolerated   = "Pool has taints not tolerated by lease"
+	PoolVCenterLimitReached = "Pool vCenter limit reached"
 )
 
 type PoolFittingInfo struct {

--- a/pkg/utils/pools_test.go
+++ b/pkg/utils/pools_test.go
@@ -327,9 +327,9 @@ func TestLeaseToleratesPoolTaints(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := leaseToleratesPoolTaints(tt.lease, tt.pool)
+			result := LeaseToleratesPoolTaints(tt.lease, tt.pool)
 			if result != tt.expected {
-				t.Errorf("leaseToleratesPoolTaints() = %v, expected %v", result, tt.expected)
+				t.Errorf("LeaseToleratesPoolTaints() = %v, expected %v", result, tt.expected)
 			}
 		})
 	}
@@ -435,9 +435,9 @@ func TestPoolMatchesSelector(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := poolMatchesSelector(tt.lease, tt.pool)
+			result := PoolMatchesSelector(tt.lease, tt.pool)
 			if result != tt.expected {
-				t.Errorf("poolMatchesSelector() = %v, expected %v", result, tt.expected)
+				t.Errorf("PoolMatchesSelector() = %v, expected %v", result, tt.expected)
 			}
 		})
 	}
@@ -1092,4 +1092,582 @@ func TestGetVCentersInUse(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGetFittingPoolsWithVCenterCap tests pool selection with vCenter constraints
+// when VCenters=1 and multiple pools are needed
+func TestGetFittingPoolsWithVCenterCap(t *testing.T) {
+	tests := []struct {
+		name                  string
+		lease                 *v1.Lease
+		pools                 []*v1.Pool
+		excludedVCenters      map[string]bool
+		expectedFittingCount  int
+		expectedExcludedCount int
+		expectVCenter         string // Expected vCenter for fitting pools
+	}{
+		{
+			name: "excludes vcenter with insufficient pools when VCenters=1",
+			lease: &v1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-lease",
+					Namespace: "default",
+				},
+				Spec: v1.LeaseSpec{
+					VCpus:    16,
+					Memory:   32,
+					Pools:    3,
+					VCenters: 1,
+				},
+			},
+			pools: []*v1.Pool{
+				// vcenter1 has only 1 pool - should be excluded
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				// vcenter2 has 3 pools - should be available
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool2"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool3"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+			},
+			excludedVCenters: map[string]bool{
+				"vcenter1.example.com": true,
+			},
+			expectedFittingCount:  3,
+			expectedExcludedCount: 1,
+			expectVCenter:         "vcenter2.example.com",
+		},
+		{
+			name: "allows vcenter with sufficient pools when VCenters=1",
+			lease: &v1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-lease",
+					Namespace: "default",
+				},
+				Spec: v1.LeaseSpec{
+					VCpus:    16,
+					Memory:   32,
+					Pools:    2,
+					VCenters: 1,
+				},
+			},
+			pools: []*v1.Pool{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool2"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+			},
+			excludedVCenters:      nil, // No exclusions
+			expectedFittingCount:  2,
+			expectedExcludedCount: 0,
+			expectVCenter:         "vcenter1.example.com",
+		},
+		{
+			name: "correctly counts only suitable pools (excludes NoSchedule)",
+			lease: &v1.Lease{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-lease",
+					Namespace: "default",
+				},
+				Spec: v1.LeaseSpec{
+					VCpus:    16,
+					Memory:   32,
+					Pools:    2,
+					VCenters: 1,
+				},
+			},
+			pools: []*v1.Pool{
+				// vcenter1 has 2 pools but one is NoSchedule
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter1-pool2"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter1.example.com",
+							},
+						},
+						VCpus:      100,
+						Memory:     1000,
+						NoSchedule: true, // This pool should be filtered out
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				// vcenter2 has 2 schedulable pools
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool1"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "vcenter2-pool2"},
+					Spec: v1.PoolSpec{
+						FailureDomainSpec: v1.FailureDomainSpec{
+							VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+								Server: "vcenter2.example.com",
+							},
+						},
+						VCpus:  100,
+						Memory: 1000,
+					},
+					Status: v1.PoolStatus{
+						VCpusAvailable:  100,
+						MemoryAvailable: 1000,
+					},
+				},
+			},
+			excludedVCenters: map[string]bool{
+				"vcenter1.example.com": true, // Should be excluded (only 1 suitable pool)
+			},
+			expectedFittingCount:  2,
+			expectedExcludedCount: 2, // vcenter1-pool2 (NoSchedule) + vcenter1-pool1 (vcenter excluded)
+			expectVCenter:         "vcenter2.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fittingPools, results := GetFittingPools(tt.lease, tt.pools, tt.excludedVCenters)
+
+			if len(fittingPools) != tt.expectedFittingCount {
+				t.Errorf("Expected %d fitting pools, got %d", tt.expectedFittingCount, len(fittingPools))
+			}
+
+			excludedCount := 0
+			for _, result := range results {
+				if result.MatchResults == PoolVCenterLimitReached || result.MatchResults == PoolNotSchedulable {
+					excludedCount++
+				}
+			}
+
+			if excludedCount != tt.expectedExcludedCount {
+				t.Errorf("Expected %d excluded pools, got %d", tt.expectedExcludedCount, excludedCount)
+			}
+
+			// Verify all fitting pools are from the expected vCenter
+			if tt.expectVCenter != "" {
+				for _, pool := range fittingPools {
+					if pool.Spec.Server != tt.expectVCenter {
+						t.Errorf("Expected pool %s to be from vCenter %s, got %s",
+							pool.Name, tt.expectVCenter, pool.Spec.Server)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestGetPoolWithStrategyMultiVCenterConstraint tests the full pool selection flow
+// with vCenter constraints
+func TestGetPoolWithStrategyMultiVCenterConstraint(t *testing.T) {
+	lease := &v1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-lease",
+			Namespace: "default",
+		},
+		Spec: v1.LeaseSpec{
+			VCpus:    16,
+			Memory:   32,
+			Pools:    3,
+			VCenters: 1,
+		},
+	}
+
+	pools := []*v1.Pool{
+		// vcenter1 has only 1 pool - insufficient
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "vspherecapacitymanager.splat.io/v1",
+				Kind:       "Pool",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vcenter1-pool1",
+				UID:  "uid-vcenter1-pool1",
+			},
+			Spec: v1.PoolSpec{
+				FailureDomainSpec: v1.FailureDomainSpec{
+					VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+						Server: "vcenter1.example.com",
+					},
+				},
+				VCpus:  100,
+				Memory: 1000,
+			},
+			Status: v1.PoolStatus{
+				VCpusAvailable:  100,
+				MemoryAvailable: 1000,
+			},
+		},
+		// vcenter2 has 3 pools - sufficient
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "vspherecapacitymanager.splat.io/v1",
+				Kind:       "Pool",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vcenter2-pool1",
+				UID:  "uid-vcenter2-pool1",
+			},
+			Spec: v1.PoolSpec{
+				FailureDomainSpec: v1.FailureDomainSpec{
+					VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+						Server: "vcenter2.example.com",
+					},
+				},
+				VCpus:  100,
+				Memory: 1000,
+			},
+			Status: v1.PoolStatus{
+				VCpusAvailable:  100,
+				MemoryAvailable: 1000,
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "vspherecapacitymanager.splat.io/v1",
+				Kind:       "Pool",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vcenter2-pool2",
+				UID:  "uid-vcenter2-pool2",
+			},
+			Spec: v1.PoolSpec{
+				FailureDomainSpec: v1.FailureDomainSpec{
+					VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+						Server: "vcenter2.example.com",
+					},
+				},
+				VCpus:  100,
+				Memory: 1000,
+			},
+			Status: v1.PoolStatus{
+				VCpusAvailable:  100,
+				MemoryAvailable: 1000,
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "vspherecapacitymanager.splat.io/v1",
+				Kind:       "Pool",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vcenter2-pool3",
+				UID:  "uid-vcenter2-pool3",
+			},
+			Spec: v1.PoolSpec{
+				FailureDomainSpec: v1.FailureDomainSpec{
+					VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+						Server: "vcenter2.example.com",
+					},
+				},
+				VCpus:  100,
+				Memory: 1000,
+			},
+			Status: v1.PoolStatus{
+				VCpusAvailable:  100,
+				MemoryAvailable: 1000,
+			},
+		},
+	}
+
+	// Exclude vcenter1 because it doesn't have enough pools
+	excludedVCenters := map[string]bool{
+		"vcenter1.example.com": true,
+	}
+
+	pool, err := GetPoolWithStrategy(lease, pools, v1.RESOURCE_ALLOCATION_STRATEGY_UNDERUTILIZED, excludedVCenters)
+	if err != nil {
+		t.Fatalf("GetPoolWithStrategy failed: %v", err)
+	}
+
+	if pool.Spec.Server != "vcenter2.example.com" {
+		t.Errorf("Expected pool from vcenter2.example.com, got %s", pool.Spec.Server)
+	}
+
+	// Verify the pool was added to lease's OwnerReferences
+	if len(lease.OwnerReferences) != 1 {
+		t.Errorf("Expected 1 owner reference, got %d", len(lease.OwnerReferences))
+	}
+
+	if lease.OwnerReferences[0].Name != pool.Name {
+		t.Errorf("Expected owner reference to pool %s, got %s", pool.Name, lease.OwnerReferences[0].Name)
+	}
+}
+
+// TestGetPoolWithStrategyVCenters2Pools3 tests the VCenters=2, Pools=3 scenario
+func TestGetPoolWithStrategyVCenters2Pools3(t *testing.T) {
+	lease := &v1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-lease",
+			Namespace: "default",
+		},
+		Spec: v1.LeaseSpec{
+			VCpus:    16,
+			Memory:   32,
+			Pools:    3,
+			VCenters: 2,
+		},
+	}
+
+	pools := []*v1.Pool{
+		// vcenter1 has only 1 pool - should be excluded (needs ceil(3/2)=2)
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "vspherecapacitymanager.splat.io/v1",
+				Kind:       "Pool",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vcenter1-pool1",
+				UID:  "uid-vcenter1-pool1",
+			},
+			Spec: v1.PoolSpec{
+				FailureDomainSpec: v1.FailureDomainSpec{
+					VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+						Server: "vcenter1.example.com",
+					},
+				},
+				VCpus:  100,
+				Memory: 1000,
+			},
+			Status: v1.PoolStatus{
+				VCpusAvailable:  100,
+				MemoryAvailable: 1000,
+			},
+		},
+		// vcenter2 has 2 pools - sufficient
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "vspherecapacitymanager.splat.io/v1",
+				Kind:       "Pool",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vcenter2-pool1",
+				UID:  "uid-vcenter2-pool1",
+			},
+			Spec: v1.PoolSpec{
+				FailureDomainSpec: v1.FailureDomainSpec{
+					VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+						Server: "vcenter2.example.com",
+					},
+				},
+				VCpus:  100,
+				Memory: 1000,
+			},
+			Status: v1.PoolStatus{
+				VCpusAvailable:  100,
+				MemoryAvailable: 1000,
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "vspherecapacitymanager.splat.io/v1",
+				Kind:       "Pool",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vcenter2-pool2",
+				UID:  "uid-vcenter2-pool2",
+			},
+			Spec: v1.PoolSpec{
+				FailureDomainSpec: v1.FailureDomainSpec{
+					VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+						Server: "vcenter2.example.com",
+					},
+				},
+				VCpus:  100,
+				Memory: 1000,
+			},
+			Status: v1.PoolStatus{
+				VCpusAvailable:  100,
+				MemoryAvailable: 1000,
+			},
+		},
+		// vcenter3 has 2 pools - sufficient
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "vspherecapacitymanager.splat.io/v1",
+				Kind:       "Pool",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vcenter3-pool1",
+				UID:  "uid-vcenter3-pool1",
+			},
+			Spec: v1.PoolSpec{
+				FailureDomainSpec: v1.FailureDomainSpec{
+					VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+						Server: "vcenter3.example.com",
+					},
+				},
+				VCpus:  100,
+				Memory: 1000,
+			},
+			Status: v1.PoolStatus{
+				VCpusAvailable:  100,
+				MemoryAvailable: 1000,
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "vspherecapacitymanager.splat.io/v1",
+				Kind:       "Pool",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "vcenter3-pool2",
+				UID:  "uid-vcenter3-pool2",
+			},
+			Spec: v1.PoolSpec{
+				FailureDomainSpec: v1.FailureDomainSpec{
+					VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+						Server: "vcenter3.example.com",
+					},
+				},
+				VCpus:  100,
+				Memory: 1000,
+			},
+			Status: v1.PoolStatus{
+				VCpusAvailable:  100,
+				MemoryAvailable: 1000,
+			},
+		},
+	}
+
+	// Exclude vcenter1 because it doesn't have enough pools (needs ceil(3/2)=2, has 1)
+	excludedVCenters := map[string]bool{
+		"vcenter1.example.com": true,
+	}
+
+	pool, err := GetPoolWithStrategy(lease, pools, v1.RESOURCE_ALLOCATION_STRATEGY_UNDERUTILIZED, excludedVCenters)
+	if err != nil {
+		t.Fatalf("GetPoolWithStrategy failed: %v", err)
+	}
+
+	// Pool should be from vcenter2 or vcenter3, not vcenter1
+	if pool.Spec.Server == "vcenter1.example.com" {
+		t.Errorf("Should not have selected pool from vcenter1 (excluded), got %s", pool.Name)
+	}
+
+	if pool.Spec.Server != "vcenter2.example.com" && pool.Spec.Server != "vcenter3.example.com" {
+		t.Errorf("Expected pool from vcenter2 or vcenter3, got %s from %s", pool.Name, pool.Spec.Server)
+	}
+
+	// Verify the pool was added to lease's OwnerReferences
+	if len(lease.OwnerReferences) != 1 {
+		t.Errorf("Expected 1 owner reference, got %d", len(lease.OwnerReferences))
+	}
+
+	t.Logf("Successfully selected pool %s from vCenter %s", pool.Name, pool.Spec.Server)
 }


### PR DESCRIPTION
[SPLAT-2238](https://redhat.atlassian.net/browse/SPLAT-2238)

### Changes
- Fixed issue where single vcenter with multiple failure domains fails due to picking vCenter with not enough pools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pool selection when a lease is limited to fewer vCenters than required pools by proactively excluding vCenters that cannot offer enough eligible pools.
  * Enhanced pre-selection filtering to better ignore unschedulable or resource-ineligible pools, improving assignment reliability under vCenter constraints.

* **Tests**
  * Added and expanded unit coverage for vCenter-cap pool availability and multi-vCenter selection, including exclusion scenarios and correct pool/ownership behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->