### PR TITLE
SPLAT-2885: Added new rejected state for when a lease has invalid lease configuration

### DIFF
--- a/pkg/apis/vspherecapacitymanager.splat.io/v1/types.go
+++ b/pkg/apis/vspherecapacitymanager.splat.io/v1/types.go
@@ -76,7 +76,8 @@ const (
 
 // all the reasons for various updates
 const (
-	ReasonLeaseDelayed string = "LeaseDelayed"
-	ReasonLeasePartial string = "LeasePartial"
-	ReasonLeaseNoPool  string = "NoAvailablePool"
+	ReasonLeaseDelayed       string = "LeaseDelayed"
+	ReasonLeasePartial       string = "LeasePartial"
+	ReasonLeaseNoPool        string = "NoAvailablePool"
+	ReasonLeaseUnschedulable string = "Unschedulable"
 )

--- a/pkg/controller/lease_satisfiability_test.go
+++ b/pkg/controller/lease_satisfiability_test.go
@@ -1,0 +1,149 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/openshift-splat-team/vsphere-capacity-manager/pkg/apis/vspherecapacitymanager.splat.io/v1"
+)
+
+func testPoolForSatisfiability(name, server string) *v1.Pool {
+	return &v1.Pool{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1.PoolSpec{
+			FailureDomainSpec: v1.FailureDomainSpec{
+				VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+					Server: server,
+				},
+			},
+		},
+	}
+}
+
+func TestFailLeaseIfUnsatisfiable(t *testing.T) {
+	t.Run("unsatisfiable lease is transitioned to Failed", func(t *testing.T) {
+		lease := &v1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Name: "impossible-lease"},
+			Spec:       v1.LeaseSpec{Pools: 4, VCenters: 1},
+			Status: v1.LeaseStatus{
+				Phase: v1.PHASE_PARTIAL,
+				PoolInfo: []v1.FailureDomainSpec{
+					{ShortName: "vc1-pool1"},
+				},
+			},
+		}
+		lease.OwnerReferences = []metav1.OwnerReference{
+			{Kind: "Pool", Name: "vc1-pool1"},
+			{Kind: "Network", Name: "net-1"},
+			{Kind: "SomeOtherKind", Name: "keep-me"},
+		}
+
+		pools := []*v1.Pool{
+			testPoolForSatisfiability("vc1-pool1", "vcenter1.example.com"),
+			testPoolForSatisfiability("vc1-pool2", "vcenter1.example.com"),
+			testPoolForSatisfiability("vc1-pool3", "vcenter1.example.com"),
+		}
+
+		failed := failLeaseIfUnsatisfiable(lease, pools)
+		if !failed {
+			t.Fatalf("expected failLeaseIfUnsatisfiable to return true")
+		}
+		if lease.Status.Phase != v1.PHASE_FAILED {
+			t.Errorf("expected Phase to be Failed, got %s", lease.Status.Phase)
+		}
+		if lease.Status.PoolInfo != nil {
+			t.Errorf("expected PoolInfo to be cleared, got %v", lease.Status.PoolInfo)
+		}
+		if len(lease.OwnerReferences) != 1 || lease.OwnerReferences[0].Kind != "SomeOtherKind" {
+			t.Errorf("expected Pool/Network owner refs to be stripped, got %v", lease.OwnerReferences)
+		}
+
+		var fulfilled *v1.Condition
+		for i := range lease.Status.Conditions {
+			if lease.Status.Conditions[i].Type == v1.LeaseConditionTypeFulfilled {
+				fulfilled = &lease.Status.Conditions[i]
+				break
+			}
+		}
+		if fulfilled == nil {
+			t.Fatalf("expected a Fulfilled condition to be set")
+		}
+		if fulfilled.Status != v1.ConditionFalse {
+			t.Errorf("expected Fulfilled condition to be False, got %s", fulfilled.Status)
+		}
+		if fulfilled.Reason != v1.ReasonLeaseUnschedulable {
+			t.Errorf("expected reason %s, got %s", v1.ReasonLeaseUnschedulable, fulfilled.Reason)
+		}
+	})
+
+	t.Run("satisfiable lease is left untouched", func(t *testing.T) {
+		lease := &v1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Name: "fine-lease"},
+			Spec:       v1.LeaseSpec{Pools: 2, VCenters: 1},
+			Status:     v1.LeaseStatus{Phase: v1.PHASE_PENDING},
+		}
+
+		pools := []*v1.Pool{
+			testPoolForSatisfiability("vc1-pool1", "vcenter1.example.com"),
+			testPoolForSatisfiability("vc1-pool2", "vcenter1.example.com"),
+		}
+
+		failed := failLeaseIfUnsatisfiable(lease, pools)
+		if failed {
+			t.Fatalf("expected failLeaseIfUnsatisfiable to return false for a satisfiable lease")
+		}
+		if lease.Status.Phase != v1.PHASE_PENDING {
+			t.Errorf("expected Phase to remain unchanged, got %s", lease.Status.Phase)
+		}
+	})
+}
+
+func TestShouldLeaseBeDelayed_SkipsFailed(t *testing.T) {
+	now := metav1.Now()
+	older := metav1.NewTime(now.Add(-time.Minute))
+
+	newLease := &v1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: "new-lease", CreationTimestamp: now},
+		Spec:       v1.LeaseSpec{NetworkType: v1.NetworkTypeSingleTenant},
+		Status:     v1.LeaseStatus{Phase: v1.PHASE_PENDING},
+	}
+
+	t.Run("an older Failed lease does not delay a newer Pending lease", func(t *testing.T) {
+		failedLease := &v1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Name: "failed-lease", CreationTimestamp: older},
+			Spec:       v1.LeaseSpec{NetworkType: v1.NetworkTypeSingleTenant},
+			Status:     v1.LeaseStatus{Phase: v1.PHASE_FAILED},
+		}
+
+		restore := setupTestLeases(map[string]*v1.Lease{
+			"default/new-lease":    newLease,
+			"default/failed-lease": failedLease,
+		})
+		defer restore()
+
+		if shouldLeaseBeDelayed(newLease) {
+			t.Errorf("expected a Failed lease to not block a newer Pending lease")
+		}
+	})
+
+	t.Run("an older Partial lease still delays a newer Pending lease", func(t *testing.T) {
+		partialLease := &v1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Name: "partial-lease", CreationTimestamp: older},
+			Spec:       v1.LeaseSpec{NetworkType: v1.NetworkTypeSingleTenant},
+			Status:     v1.LeaseStatus{Phase: v1.PHASE_PARTIAL},
+		}
+
+		restore := setupTestLeases(map[string]*v1.Lease{
+			"default/new-lease":     newLease,
+			"default/partial-lease": partialLease,
+		})
+		defer restore()
+
+		if !shouldLeaseBeDelayed(newLease) {
+			t.Errorf("expected a Partial lease to still block a newer Pending lease")
+		}
+	})
+}

--- a/pkg/controller/leases.go
+++ b/pkg/controller/leases.go
@@ -440,6 +440,37 @@ func (l *LeaseReconciler) getCommonNetworksForLease(lease *v1.Lease) ([]*v1.Netw
 	return nil, fmt.Errorf("no common network found for %s", lease.Name)
 }
 
+// failLeaseIfUnsatisfiable checks whether lease can ever be fulfilled given the full pool
+// inventory. If not, it mutates lease (OwnerReferences + Status) into a terminal Failed
+// state and returns true; the caller is responsible for persisting lease via the client.
+func failLeaseIfUnsatisfiable(lease *v1.Lease, allPools []*v1.Pool) bool {
+	ok, reason := utils.IsLeaseSatisfiable(lease, allPools)
+	if ok {
+		return false
+	}
+
+	log.Printf("lease %s is not satisfiable: %s", lease.Name, reason)
+
+	newOwnerRefs := []metav1.OwnerReference{}
+	for _, ref := range lease.OwnerReferences {
+		if ref.Kind != "Pool" && ref.Kind != "Network" {
+			newOwnerRefs = append(newOwnerRefs, ref)
+		}
+	}
+	lease.OwnerReferences = newOwnerRefs
+	lease.Status.PoolInfo = nil
+	lease.Status.EnvVarsMap = nil
+	lease.Status.Topology.Networks = nil
+	lease.Status.Phase = v1.PHASE_FAILED
+
+	conditions.Set(lease, conditions.FalseConditionWithReason(
+		v1.LeaseConditionTypeFulfilled, v1.ReasonLeaseUnschedulable, v1.ConditionSeverityError, reason))
+	conditions.Set(lease, conditions.FalseCondition(v1.LeaseConditionTypePending))
+	conditions.Set(lease, conditions.FalseCondition(v1.LeaseConditionTypePartial))
+	conditions.Set(lease, conditions.FalseCondition(v1.LeaseConditionTypeDelayed))
+	return true
+}
+
 // shouldLeaseBeDelayed is used to determine if current lease should be delayed.
 func shouldLeaseBeDelayed(lease *v1.Lease) bool {
 	// Iterate through all leases.  Ignore fulfilled.  If we see Partial, block if needing same pool.  If Pending, we
@@ -469,6 +500,8 @@ func shouldLeaseBeDelayed(lease *v1.Lease) bool {
 
 			switch curLease.Status.Phase {
 			case v1.PHASE_FULFILLED:
+				continue
+			case v1.PHASE_FAILED:
 				continue
 			case v1.PHASE_PARTIAL:
 				// We want partial to prevent others wanting same pool.
@@ -657,12 +690,30 @@ func (l *LeaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	leases[leaseKey] = lease
 
-	if lease.Status.Phase == v1.PHASE_FULFILLED {
-		log.Print("lease is already fulfilled")
+	if lease.Status.Phase == v1.PHASE_FULFILLED || lease.Status.Phase == v1.PHASE_FAILED {
+		log.Print("lease is already fulfilled or failed")
 		return ctrl.Result{}, nil
 	}
 
 	updatedPools := reconcilePoolStates()
+
+	if failLeaseIfUnsatisfiable(lease, updatedPools) {
+		if err := l.Client.Update(ctx, lease); err != nil {
+			return ctrl.Result{}, fmt.Errorf("error releasing owner refs for unschedulable lease: %w", err)
+		}
+		LeaseTransitionsTotal.With(prometheus.Labels{
+			"namespace":   lease.Namespace,
+			"networkType": string(lease.Spec.NetworkType),
+			"phase":       string(v1.PHASE_FAILED),
+		}).Inc()
+		if err := l.Client.Status().Update(ctx, lease); err != nil {
+			return ctrl.Result{}, fmt.Errorf("error updating lease status to Failed: %w", err)
+		}
+		l.triggerPoolUpdates(ctx)
+		l.triggerLeaseUpdates(ctx, lease.Spec.NetworkType)
+		updateLeaseMetrics()
+		return ctrl.Result{}, nil
+	}
 
 	// TODO: How often are we hitting this and can we remove this and just use the one above?
 	if len(lease.Status.Phase) == 0 {

--- a/pkg/utils/pools.go
+++ b/pkg/utils/pools.go
@@ -105,6 +105,92 @@ func GetVCentersInUse(assignedPools []*v1.Pool) map[string]bool {
 	return vcenters
 }
 
+// poolMatchesStructural reports whether a pool structurally matches a lease's requirements,
+// ignoring transient state such as current resource availability, current ownership, and
+// any vCenter exclusions computed for a particular reconcile pass. It captures only the
+// checks that depend on static configuration (RequiredPool/Exclude, PoolSelector,
+// Tolerations, NoSchedule), which is what determines whether a request could ever be
+// satisfied by this pool, as opposed to whether it can be satisfied right now.
+func poolMatchesStructural(lease *v1.Lease, pool *v1.Pool) bool {
+	if pool.Spec.NoSchedule {
+		return false
+	}
+	nameMatch := len(lease.Spec.RequiredPool) > 0 && lease.Spec.RequiredPool == pool.ObjectMeta.Name
+	if !nameMatch && pool.Spec.Exclude {
+		return false
+	}
+	if len(lease.Spec.RequiredPool) > 0 && !nameMatch {
+		return false
+	}
+	if !PoolMatchesSelector(lease, pool) {
+		return false
+	}
+	if !LeaseToleratesPoolTaints(lease, pool) {
+		return false
+	}
+	return true
+}
+
+// MaxAchievablePools returns the maximum number of pools a lease could ever be assigned,
+// given the full known pool inventory and the lease's structural constraints (RequiredPool,
+// PoolSelector, Tolerations, NoSchedule/Exclude) and its VCenters cap. It deliberately
+// ignores current resource availability and existing ownership, since those are transient:
+// this answers "can this request ever be satisfied," not "can it be satisfied right now."
+func MaxAchievablePools(lease *v1.Lease, allPools []*v1.Pool) int {
+	poolsPerVCenter := make(map[string]int)
+	for _, pool := range allPools {
+		if !poolMatchesStructural(lease, pool) {
+			continue
+		}
+		poolsPerVCenter[pool.Spec.Server]++
+	}
+
+	if lease.Spec.VCenters <= 0 {
+		total := 0
+		for _, count := range poolsPerVCenter {
+			total += count
+		}
+		return total
+	}
+
+	counts := make([]int, 0, len(poolsPerVCenter))
+	for _, count := range poolsPerVCenter {
+		counts = append(counts, count)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(counts)))
+
+	n := lease.Spec.VCenters
+	if n > len(counts) {
+		n = len(counts)
+	}
+	total := 0
+	for i := 0; i < n; i++ {
+		total += counts[i]
+	}
+	return total
+}
+
+// IsLeaseSatisfiable reports whether a lease's request could ever be fulfilled given the
+// full known pool inventory. It returns false with an explanatory reason when the lease's
+// Pools/VCenters requirements structurally exceed what the known inventory can ever provide,
+// regardless of current utilization by other leases.
+func IsLeaseSatisfiable(lease *v1.Lease, allPools []*v1.Pool) (bool, string) {
+	requiredPools := lease.Spec.Pools
+	if requiredPools == 0 {
+		requiredPools = 1
+	}
+
+	maxAchievable := MaxAchievablePools(lease, allPools)
+	if maxAchievable >= requiredPools {
+		return true, ""
+	}
+
+	return false, fmt.Sprintf(
+		"lease requires %d pool(s) (vcenters cap %d) but at most %d are structurally achievable given the known pool inventory",
+		requiredPools, lease.Spec.VCenters, maxAchievable,
+	)
+}
+
 // GetFittingPools returns a list of pools that have enough resources to satisfy the resource requirements and a list of
 // PoolFittingInfo specifying why pool is not a match.
 // The list is sorted by the sum of the resource usage of the pool. The pool with the least resource usage is first.

--- a/pkg/utils/pools_test.go
+++ b/pkg/utils/pools_test.go
@@ -1671,3 +1671,179 @@ func TestGetPoolWithStrategyVCenters2Pools3(t *testing.T) {
 
 	t.Logf("Successfully selected pool %s from vCenter %s", pool.Name, pool.Spec.Server)
 }
+
+// testPool builds a minimal pool on the given vcenter server, with optional name/labels/taints.
+func testPool(name, server string) *v1.Pool {
+	return &v1.Pool{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1.PoolSpec{
+			FailureDomainSpec: v1.FailureDomainSpec{
+				VSpherePlatformFailureDomainSpec: configv1.VSpherePlatformFailureDomainSpec{
+					Server: server,
+				},
+			},
+		},
+	}
+}
+
+func TestMaxAchievablePools(t *testing.T) {
+	tests := []struct {
+		name     string
+		lease    *v1.Lease
+		pools    []*v1.Pool
+		expected int
+	}{
+		{
+			name: "single vcenter with 3 pools, capped at 1 vcenter",
+			lease: &v1.Lease{
+				Spec: v1.LeaseSpec{Pools: 4, VCenters: 1},
+			},
+			pools: []*v1.Pool{
+				testPool("vc1-pool1", "vcenter1.example.com"),
+				testPool("vc1-pool2", "vcenter1.example.com"),
+				testPool("vc1-pool3", "vcenter1.example.com"),
+			},
+			expected: 3,
+		},
+		{
+			name: "unconstrained vcenters sums all matching pools",
+			lease: &v1.Lease{
+				Spec: v1.LeaseSpec{Pools: 5, VCenters: 0},
+			},
+			pools: []*v1.Pool{
+				testPool("vc1-pool1", "vcenter1.example.com"),
+				testPool("vc2-pool1", "vcenter2.example.com"),
+				testPool("vc3-pool1", "vcenter3.example.com"),
+			},
+			expected: 3,
+		},
+		{
+			name: "vcenters cap is the binding constraint, not raw pool count",
+			lease: &v1.Lease{
+				Spec: v1.LeaseSpec{Pools: 4, VCenters: 2},
+			},
+			pools: []*v1.Pool{
+				testPool("vc1-pool1", "vcenter1.example.com"),
+				testPool("vc1-pool2", "vcenter1.example.com"),
+				testPool("vc2-pool1", "vcenter2.example.com"),
+				testPool("vc2-pool2", "vcenter2.example.com"),
+				testPool("vc3-pool1", "vcenter3.example.com"),
+				testPool("vc3-pool2", "vcenter3.example.com"),
+			},
+			// best 2 vcenters combined only ever provide 4 pools, even though 6 exist total
+			expected: 4,
+		},
+		{
+			name: "requiredPool naming a nonexistent pool yields zero",
+			lease: &v1.Lease{
+				Spec: v1.LeaseSpec{Pools: 1, RequiredPool: "does-not-exist"},
+			},
+			pools: []*v1.Pool{
+				testPool("vc1-pool1", "vcenter1.example.com"),
+			},
+			expected: 0,
+		},
+		{
+			name: "poolSelector narrows structural match even with ample capacity elsewhere",
+			lease: &v1.Lease{
+				Spec: v1.LeaseSpec{
+					Pools:        2,
+					PoolSelector: map[string]string{"region": "us-west"},
+				},
+			},
+			pools: []*v1.Pool{
+				func() *v1.Pool {
+					p := testPool("vc1-pool1", "vcenter1.example.com")
+					p.Labels = map[string]string{"region": "us-west"}
+					return p
+				}(),
+				testPool("vc1-pool2", "vcenter1.example.com"), // no matching label
+				testPool("vc1-pool3", "vcenter1.example.com"), // no matching label
+			},
+			expected: 1,
+		},
+		{
+			name: "tolerations narrow structural match even with ample capacity elsewhere",
+			lease: &v1.Lease{
+				Spec: v1.LeaseSpec{Pools: 2},
+			},
+			pools: []*v1.Pool{
+				func() *v1.Pool {
+					p := testPool("vc1-pool1", "vcenter1.example.com")
+					p.Spec.Taints = []v1.Taint{{Key: "dedicated", Value: "gpu", Effect: v1.TaintEffectNoSchedule}}
+					return p
+				}(),
+				testPool("vc1-pool2", "vcenter1.example.com"),
+			},
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MaxAchievablePools(tt.lease, tt.pools)
+			if result != tt.expected {
+				t.Errorf("MaxAchievablePools() = %d, expected %d", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsLeaseSatisfiable(t *testing.T) {
+	tests := []struct {
+		name     string
+		lease    *v1.Lease
+		pools    []*v1.Pool
+		expected bool
+	}{
+		{
+			name: "reported bug repro: 4 pools needed from 1 vcenter that only has 3",
+			lease: &v1.Lease{
+				Spec: v1.LeaseSpec{Pools: 4, VCenters: 1},
+			},
+			pools: []*v1.Pool{
+				testPool("vc1-pool1", "vcenter1.example.com"),
+				testPool("vc1-pool2", "vcenter1.example.com"),
+				testPool("vc1-pool3", "vcenter1.example.com"),
+			},
+			expected: false,
+		},
+		{
+			name: "same inventory but requesting only 3 pools is satisfiable",
+			lease: &v1.Lease{
+				Spec: v1.LeaseSpec{Pools: 3, VCenters: 1},
+			},
+			pools: []*v1.Pool{
+				testPool("vc1-pool1", "vcenter1.example.com"),
+				testPool("vc1-pool2", "vcenter1.example.com"),
+				testPool("vc1-pool3", "vcenter1.example.com"),
+			},
+			expected: true,
+		},
+		{
+			name: "default pool count of 1 is satisfiable with any matching pool",
+			lease: &v1.Lease{
+				Spec: v1.LeaseSpec{},
+			},
+			pools: []*v1.Pool{
+				testPool("vc1-pool1", "vcenter1.example.com"),
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, reason := IsLeaseSatisfiable(tt.lease, tt.pools)
+			if ok != tt.expected {
+				t.Errorf("IsLeaseSatisfiable() = (%v, %q), expected ok=%v", ok, reason, tt.expected)
+			}
+			if !ok && reason == "" {
+				t.Errorf("IsLeaseSatisfiable() returned false with no reason")
+			}
+			if ok && reason != "" {
+				t.Errorf("IsLeaseSatisfiable() returned true with a non-empty reason %q", reason)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[SPLAT-2885](https://redhat.atlassian.net/browse/SPLAT-2885)

### Changes
- Added logic to detect if lease is requesting an invalid fd / vcenter lease configuration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Leases that cannot be satisfied by available pool inventory are now marked **Failed** with an explanatory reason.
  * Unsatisfiable leases release associated pool and network allocations.
  * Lease evaluation now accounts for pool constraints, selectors, tolerations, required pools, and vCenter limits.
  * Failed leases no longer delay or block newer pending leases.

* **Bug Fixes**
  * Improved lease status and condition updates when requested capacity cannot be achieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->